### PR TITLE
fix: validate and auto-fix base_url protocol prefix

### DIFF
--- a/InsightEngine/llms/base.py
+++ b/InsightEngine/llms/base.py
@@ -37,7 +37,7 @@ class LLMClient:
             raise ValueError("Insight Engine INSIGHT_ENGINE_MODEL_NAME is required.")
 
         self.api_key = api_key
-        self.base_url = base_url
+        self.base_url = self._validate_base_url(base_url) if base_url else base_url
         self.model_name = model_name
         self.provider = model_name
         timeout_fallback = os.getenv("LLM_REQUEST_TIMEOUT") or os.getenv("INSIGHT_ENGINE_REQUEST_TIMEOUT") or "1800"

--- a/MediaEngine/llms/base.py
+++ b/MediaEngine/llms/base.py
@@ -33,6 +33,28 @@ class LLMClient:
     Minimal wrapper around the OpenAI-compatible chat completion API.
     """
 
+    @staticmethod
+    def _validate_base_url(base_url: str) -> str:
+        """Validate and normalize base_url to ensure it has a protocol prefix."""
+        if not base_url:
+            return base_url
+        
+        base_url = base_url.strip()
+        
+        # Check if URL already has a protocol
+        if base_url.startswith(('http://', 'https://')):
+            return base_url
+        
+        # Auto-add https:// prefix if missing
+        import warnings
+        warnings.warn(
+            f"base_url '{base_url}' is missing 'http://' or 'https://' protocol prefix. "
+            f"Auto-prepending 'https://'. Please update your configuration.",
+            UserWarning
+        )
+        return f"https://{base_url}"
+
+
     def __init__(self, api_key: str, model_name: str, base_url: Optional[str] = None):
         if not api_key:
             raise ValueError("Media Engine LLM API key is required.")
@@ -40,7 +62,7 @@ class LLMClient:
             raise ValueError("Media Engine model name is required.")
 
         self.api_key = api_key
-        self.base_url = base_url
+        self.base_url = self._validate_base_url(base_url) if base_url else base_url
         self.model_name = model_name
         self.provider = model_name
         timeout_fallback = os.getenv("LLM_REQUEST_TIMEOUT") or os.getenv("MEDIA_ENGINE_REQUEST_TIMEOUT") or "1800"


### PR DESCRIPTION
## Summary

Fixes #602 - 验证并自动修复 LLM base_url 缺少协议前缀的问题。

## Problem

用户配置 `MEDIA_ENGINE_BASE_URL=api.example.com` 时，OpenAI 客户端会报错：
```
httpcore.UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
```

## Solution

- 添加 `_validate_base_url` 方法验证 base_url
- 如果缺少 `http://` 或 `https://` 前缀，自动补全 `https://`
- 发出警告提示用户修正配置

## Changes

- `MediaEngine/llms/base.py`: 添加 base_url 验证
- `InsightEngine/llms/base.py`: 添加 base_url 验证

## Example

```python
# 用户配置
MEDIA_ENGINE_BASE_URL=api.example.com

# 自动修复为
https://api.example.com
```

Fixes #602