### PR TITLE
fix: add hint to run --init-db when tables missing

### DIFF
--- a/MindSpider/main.py
+++ b/MindSpider/main.py
@@ -129,7 +129,10 @@ class MindSpider:
             missing_tables = [t for t in required_tables if t not in existing_tables]
             if missing_tables:
                 logger.error(f"缺少数据库表: {', '.join(missing_tables)}")
-                logger.info("提示: 请运行 'python main.py --init-db' 初始化数据库表")
+                logger.info(
+                    "提示: 请在 MindSpider 目录运行 'python main.py --init-db'，"
+                    "或在仓库根目录运行 'python MindSpider/main.py --init-db' 初始化数据库表"
+                )
                 return False
             logger.info("数据库表检查通过")
             return True

--- a/MindSpider/main.py
+++ b/MindSpider/main.py
@@ -129,6 +129,7 @@ class MindSpider:
             missing_tables = [t for t in required_tables if t not in existing_tables]
             if missing_tables:
                 logger.error(f"缺少数据库表: {', '.join(missing_tables)}")
+                logger.info("提示: 请运行 'python main.py --init-db' 初始化数据库表")
                 return False
             logger.info("数据库表检查通过")
             return True

--- a/tests/test_mindspider_database_hint.py
+++ b/tests/test_mindspider_database_hint.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from MindSpider import main as mindspider_main
+
+
+class FakeConnection:
+    def __init__(self, tables):
+        self.tables = tables
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def run_sync(self, callback):
+        return self.tables
+
+
+class FakeEngine:
+    def __init__(self, tables):
+        self.tables = tables
+
+    def connect(self):
+        return FakeConnection(self.tables)
+
+    async def dispose(self):
+        return None
+
+
+def test_missing_tables_hint_supports_documented_working_directories(monkeypatch):
+    logger = Mock()
+    settings = SimpleNamespace(
+        DB_DIALECT="postgresql",
+        DB_USER="user",
+        DB_PASSWORD="password",
+        DB_HOST="localhost",
+        DB_PORT=5432,
+        DB_NAME="bettafish",
+        DB_CHARSET="utf8mb4",
+    )
+    monkeypatch.setattr(mindspider_main, "logger", logger)
+    monkeypatch.setattr(mindspider_main, "settings", settings)
+    monkeypatch.setattr(
+        mindspider_main,
+        "create_async_engine",
+        lambda *args, **kwargs: FakeEngine(["daily_news"]),
+    )
+
+    assert mindspider_main.MindSpider().check_database_tables() is False
+
+    info_messages = [call.args[0] for call in logger.info.call_args_list]
+    hint = next(message for message in info_messages if message.startswith("提示:"))
+    assert "python main.py --init-db" in hint
+    assert "python MindSpider/main.py --init-db" in hint


### PR DESCRIPTION
## Summary

Fixes #599 - 当数据库表缺失时，提示用户运行初始化命令。

## Problem

用户运行 `python main.py --status` 时，如果数据库表不存在，只显示：
```
缺少数据库表: daily_news, daily_topics
数据库表: 需要初始化
```

用户不知道如何初始化。

## Solution

在错误消息后添加提示：
```
提示: 请运行 'python main.py --init-db' 初始化数据库表
```

## Changes

- `MindSpider/main.py`: 在 `check_database_tables()` 中添加提示

Fixes #599