### PR TITLE
fix: specify UTF-8 encoding for subprocess in init_database

### DIFF
--- a/MindSpider/main.py
+++ b/MindSpider/main.py
@@ -151,7 +151,8 @@ class MindSpider:
                 [sys.executable, str(init_script)],
                 cwd=self.schema_path,
                 capture_output=True,
-                text=True
+                text=True,
+                encoding='utf-8'
             )
             
             if result.returncode == 0:


### PR DESCRIPTION
## Summary

Fixes #605 - 修复 Windows 上数据库初始化的 GBK 编码错误。

## Problem

用户在 Windows 上运行 `python main.py --init-db` 时遇到：
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 7223: illegal multibyte sequence
```

## Root Cause

`subprocess.run` 的 `text=True` 参数在 Windows 上默认使用系统编码 (GBK)，而不是 UTF-8。当 SQL 文件包含 UTF-8 字符时，会导致解码失败。

## Solution

显式指定 `encoding='utf-8'` 参数。

## Changes

- `MindSpider/main.py`: 在 `initialize_database()` 的 subprocess.run 中添加 `encoding='utf-8'`

Fixes #605