### PR TITLE
fix: 稳定 DeepSentimentCrawling 的 PostgreSQL 集成链路

### DIFF
--- a/MindSpider/DeepSentimentCrawling/platform_crawler.py
+++ b/MindSpider/DeepSentimentCrawling/platform_crawler.py
@@ -137,6 +137,9 @@ postgresql_db_config = {{
     "db_name": POSTGRESQL_DB_NAME,
 }}
 
+# MediaCrawler compatibility alias for postgres config name
+postgres_db_config = postgresql_db_config
+
 '''
             
             # 写入新配置
@@ -169,7 +172,7 @@ postgresql_db_config = {{
             # 判断数据库类型，确定 SAVE_DATA_OPTION
             db_dialect = (config.settings.DB_DIALECT or "mysql").lower()
             is_postgresql = db_dialect in ("postgresql", "postgres")
-            save_data_option = "postgresql" if is_postgresql else "db"
+            save_data_option = "postgres" if is_postgresql else "db"
             
             base_config_path = self.mediacrawler_path / "config" / "base_config.py"
             
@@ -180,17 +183,27 @@ postgresql_db_config = {{
             with open(base_config_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             
-            # 修改关键配置项
+            # Replace config lines carefully; only skip continuation lines when CRAWLER_TYPE uses multi-line parentheses.
             lines = content.split('\n')
             new_lines = []
-            
+            skip_crawler_type_continuation = False
+
             for line in lines:
+                if skip_crawler_type_continuation:
+                    stripped = line.strip()
+                    if stripped == ')':
+                        skip_crawler_type_continuation = False
+                        continue
+                    continue
+
                 if line.startswith('PLATFORM = '):
-                    new_lines.append(f'PLATFORM = "{platform}"  # 平台，xhs | dy | ks | bili | wb | tieba | zhihu')
+                    new_lines.append(f'PLATFORM = "{platform}"  # platform: xhs | dy | ks | bili | wb | tieba | zhihu')
                 elif line.startswith('KEYWORDS = '):
-                    new_lines.append(f'KEYWORDS = "{keywords_str}"  # 关键词搜索配置，以英文逗号分隔')
+                    new_lines.append(f'KEYWORDS = "{keywords_str}"  # keyword search configuration, separated by commas')
                 elif line.startswith('CRAWLER_TYPE = '):
-                    new_lines.append(f'CRAWLER_TYPE = "{crawler_type}"  # 爬取类型，search(关键词搜索) | detail(帖子详情)| creator(创作者主页数据)')
+                    new_lines.append(f'CRAWLER_TYPE = "{crawler_type}"  # search | detail | creator')
+                    stripped = line.strip()
+                    skip_crawler_type_continuation = stripped.endswith('(') or ('(' in stripped and ')' not in stripped)
                 elif line.startswith('SAVE_DATA_OPTION = '):
                     new_lines.append(f'SAVE_DATA_OPTION = "{save_data_option}"  # csv or db or json or sqlite or postgresql')
                 elif line.startswith('CRAWLER_MAX_NOTES_COUNT = '):
@@ -200,10 +213,22 @@ postgresql_db_config = {{
                 elif line.startswith('CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES = '):
                     new_lines.append('CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES = 20')
                 elif line.startswith('HEADLESS = '):
-                    new_lines.append('HEADLESS = True')  # 使用无头模式
+                    new_lines.append('HEADLESS = False')  # keep browser visible for QR-code login and debugging
                 else:
                     new_lines.append(line)
-            
+
+            # Append fallback options when the current MediaCrawler version does not define them.
+            if 'ENABLE_GET_COMMENTS =' not in content:
+                new_lines.append('ENABLE_GET_COMMENTS = True')
+            if 'ENABLE_GET_SUB_COMMENTS =' not in content:
+                new_lines.append('ENABLE_GET_SUB_COMMENTS = False')
+            if 'CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES =' not in content:
+                new_lines.append('CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES = 20')
+            if 'START_DAY =' not in content:
+                new_lines.append('START_DAY = "2024-01-01"')
+            if 'END_DAY =' not in content:
+                new_lines.append('END_DAY = "2024-01-01"')
+
             # 写入新配置
             with open(base_config_path, 'w', encoding='utf-8') as f:
                 f.write('\n'.join(new_lines))
@@ -253,7 +278,7 @@ postgresql_db_config = {{
             # 判断数据库类型，确定 save_data_option
             db_dialect = (config.settings.DB_DIALECT or "mysql").lower()
             is_postgresql = db_dialect in ("postgresql", "postgres")
-            save_data_option = "postgresql" if is_postgresql else "db"
+            save_data_option = "postgres" if is_postgresql else "db"
             
             # 构建命令
             cmd = [


### PR DESCRIPTION
fix: 稳定 DeepSentimentCrawling 的 PostgreSQL 集成链路

  描述

  ### 变更概述
  这个 PR 修复并增强了 DeepSentimentCrawling 与 MediaCrawler 在 PostgreSQL 场景下的集成稳定性。

  ### 问题背景

  #### 1. platform_crawler.py 生成配置时会截断内容
  create_base_config() 在处理 CRAWLER_TYPE 的多行写法时，会错误地截断后续配置，导致后面的配置项丢失，例如：

  - ENABLE_GET_COMMENTS
  - CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES
  - HEADLESS
  - 其他后续配置项

  #### 2. PostgreSQL 保存选项命名不一致
  集成层之前使用的是 postgresql，但 MediaCrawler 实际兼容的是 postgres，导致保存参数对不上。

  #### 3. 某些版本的 MediaCrawler 缺少必要配置项
  集成层没有保证以下字段一定存在：

  - ENABLE_GET_COMMENTS
  - ENABLE_GET_SUB_COMMENTS
  - CRAWLER_MAX_COMMENTS_COUNT_SINGLENOTES
  - START_DAY
  - END_DAY

  ### 本次修改内容
  - 将保存选项统一改为 postgres
  - 修复 create_base_config()，避免在重写配置时截断后续内容
  - 在缺失时自动补充必要的 fallback 配置项
  - 集成流程中默认保留可见浏览器，方便二维码登录和调试
  - 更新 MediaCrawler 子模块指针，纳入 Zhihu / Douyin 的 PostgreSQL 入库兼容修复

  ### 修改文件
  - MindSpider/DeepSentimentCrawling/platform_crawler.py
  - MindSpider/DeepSentimentCrawling/MediaCrawler（submodule 指针更新）

  ### 验证情况
  本地集成验证结果如下：

  - BroadTopicExtraction：正常
  - xhs 抓取 + 入库：正常
  - zhihu 抓取 + 入库：正常
  - bili 抓取 + 入库：正常
  - dy 内容入库：正常

  ### 说明
  这个 PR 不包含本地日志、测试数据目录和临时实验文件。