### PR TITLE
fix: cancel_task returning 404 after successful cancel, and KeyError on forum app

### DIFF
--- a/ReportEngine/flask_interface.py
+++ b/ReportEngine/flask_interface.py
@@ -999,6 +999,7 @@ def cancel_task(task_id: str):
 
     try:
         with task_lock:
+            cancelled = False
             if current_task and current_task.task_id == task_id:
                 if current_task.status == "running":
                     current_task.update_status("cancelled", 0, "用户取消任务")
@@ -1006,6 +1007,7 @@ def cancel_task(task_id: str):
                         'message': '任务被用户主动终止',
                         'task': current_task.to_dict(),
                     })
+                    cancelled = True
                 current_task = None
             task = tasks_registry.get(task_id)
             if task and task.status == 'running':
@@ -1014,7 +1016,9 @@ def cancel_task(task_id: str):
                     'message': '任务被用户主动终止',
                     'task': task.to_dict(),
                 })
+                cancelled = True
 
+            if cancelled or (task and task.status == 'cancelled'):
                 return jsonify({
                     'success': True,
                     'message': '任务已取消'

--- a/app.py
+++ b/app.py
@@ -1171,8 +1171,10 @@ def search():
     # 向运行中的应用发送搜索请求
     results = {}
     api_ports = {'insight': 8501, 'media': 8502, 'query': 8503}
-    
+
     for app_name in running_apps:
+        if app_name not in api_ports:
+            continue
         try:
             api_port = api_ports[app_name]
             # 调用Streamlit应用的API端点

--- a/tests/test_report_cancel_route.py
+++ b/tests/test_report_cancel_route.py
@@ -1,0 +1,121 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+def _remove_modules(prefix):
+    saved = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name == prefix or name.startswith(f"{prefix}.")
+    }
+    for name in saved:
+        sys.modules.pop(name, None)
+    return saved
+
+
+@pytest.fixture
+def report_interface(monkeypatch):
+    saved_modules = _remove_modules("ReportEngine")
+
+    agent_module = ModuleType("ReportEngine.agent")
+    agent_module.ReportAgent = type("ReportAgent", (), {})
+    agent_module.create_agent = lambda *args, **kwargs: None
+
+    nodes_module = ModuleType("ReportEngine.nodes")
+    nodes_module.ChapterJsonParseError = type("ChapterJsonParseError", (Exception,), {})
+
+    utils_package = ModuleType("ReportEngine.utils")
+    utils_package.__path__ = []
+    config_module = ModuleType("ReportEngine.utils.config")
+    config_module.settings = SimpleNamespace()
+
+    monkeypatch.setitem(sys.modules, "ReportEngine.agent", agent_module)
+    monkeypatch.setitem(sys.modules, "ReportEngine.nodes", nodes_module)
+    monkeypatch.setitem(sys.modules, "ReportEngine.utils", utils_package)
+    monkeypatch.setitem(sys.modules, "ReportEngine.utils.config", config_module)
+
+    module = importlib.import_module("ReportEngine.flask_interface")
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(module.report_bp, url_prefix="/api/report")
+
+    try:
+        yield module, flask_app.test_client()
+    finally:
+        _remove_modules("ReportEngine")
+        sys.modules.update(saved_modules)
+
+
+def _task(module, task_id, status):
+    task = module.ReportTask(query="test", task_id=task_id)
+    task.status = status
+    return task
+
+
+def test_cancel_current_running_task_returns_success(report_interface):
+    module, client = report_interface
+    task = _task(module, "current-running", "running")
+    module.current_task = task
+    module.tasks_registry.clear()
+
+    response = client.post("/api/report/cancel/current-running")
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert task.status == "cancelled"
+    assert module.current_task is None
+
+
+def test_cancel_registry_running_task_returns_success(report_interface):
+    module, client = report_interface
+    task = _task(module, "registry-running", "running")
+    module.current_task = None
+    module.tasks_registry.clear()
+    module.tasks_registry[task.task_id] = task
+
+    response = client.post("/api/report/cancel/registry-running")
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert task.status == "cancelled"
+
+
+def test_cancel_already_cancelled_task_is_idempotent(report_interface):
+    module, client = report_interface
+    task = _task(module, "already-cancelled", "cancelled")
+    module.current_task = None
+    module.tasks_registry.clear()
+    module.tasks_registry[task.task_id] = task
+
+    response = client.post("/api/report/cancel/already-cancelled")
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+
+
+@pytest.mark.parametrize("status", ["completed", "error"])
+def test_cancel_terminal_task_returns_not_found(report_interface, status):
+    module, client = report_interface
+    task = _task(module, f"terminal-{status}", status)
+    module.current_task = None
+    module.tasks_registry.clear()
+    module.tasks_registry[task.task_id] = task
+
+    response = client.post(f"/api/report/cancel/{task.task_id}")
+
+    assert response.status_code == 404
+    assert response.get_json()["success"] is False
+
+
+def test_cancel_missing_task_returns_not_found(report_interface):
+    module, client = report_interface
+    module.current_task = None
+    module.tasks_registry.clear()
+
+    response = client.post("/api/report/cancel/missing")
+
+    assert response.status_code == 404
+    assert response.get_json()["success"] is False

--- a/tests/test_search_route.py
+++ b/tests/test_search_route.py
@@ -1,0 +1,135 @@
+import atexit
+import importlib.util
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Blueprint
+
+
+class DummyThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+class DummySocketIO:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+    def on(self, _event):
+        return lambda function: function
+
+    def run(self, *args, **kwargs):
+        pass
+
+    def stop(self):
+        pass
+
+
+def _remove_modules(prefixes):
+    saved = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
+    }
+    for name in saved:
+        sys.modules.pop(name, None)
+    return saved
+
+
+@pytest.fixture
+def root_app(monkeypatch, tmp_path):
+    prefixes = ("bettafish_app_under_test", "MindSpider", "ReportEngine", "flask_socketio")
+    saved_modules = _remove_modules(prefixes)
+
+    mindspider_package = ModuleType("MindSpider")
+    mindspider_package.__path__ = []
+    mindspider_main = ModuleType("MindSpider.main")
+    mindspider_main.MindSpider = type("MindSpider", (), {})
+
+    report_package = ModuleType("ReportEngine")
+    report_package.__path__ = []
+    report_interface = ModuleType("ReportEngine.flask_interface")
+    report_interface.report_bp = Blueprint("stub_report", __name__)
+    report_interface.initialize_report_engine = lambda: True
+
+    socketio_module = ModuleType("flask_socketio")
+    socketio_module.SocketIO = DummySocketIO
+    socketio_module.emit = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "MindSpider", mindspider_package)
+    monkeypatch.setitem(sys.modules, "MindSpider.main", mindspider_main)
+    monkeypatch.setitem(sys.modules, "ReportEngine", report_package)
+    monkeypatch.setitem(sys.modules, "ReportEngine.flask_interface", report_interface)
+    monkeypatch.setitem(sys.modules, "flask_socketio", socketio_module)
+    monkeypatch.chdir(tmp_path)
+
+    source_path = Path(__file__).resolve().parents[1] / "app.py"
+    spec = importlib.util.spec_from_file_location("bettafish_app_under_test", source_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+
+    with patch.object(threading, "Thread", DummyThread), patch.object(
+        atexit, "register", lambda *args, **kwargs: None
+    ):
+        spec.loader.exec_module(module)
+
+    try:
+        yield module, module.app.test_client()
+    finally:
+        _remove_modules(prefixes)
+        sys.modules.update(saved_modules)
+
+
+def test_search_skips_forum_and_calls_searchable_engine(root_app, monkeypatch):
+    module, client = root_app
+    module.processes = {
+        "insight": {"status": "running"},
+        "forum": {"status": "running"},
+    }
+    monkeypatch.setattr(module, "check_app_status", lambda: None)
+    engine_response = Mock(status_code=200)
+    engine_response.json.return_value = {"success": True, "items": ["result"]}
+    post = Mock(return_value=engine_response)
+    monkeypatch.setattr(module.requests, "post", post)
+
+    response = client.post("/api/search", json={"query": "BettaFish"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "query": "BettaFish",
+        "results": {"insight": {"success": True, "items": ["result"]}},
+    }
+    post.assert_called_once_with(
+        "http://localhost:8501/api/search",
+        json={"query": "BettaFish"},
+        timeout=10,
+    )
+
+
+def test_search_with_only_forum_returns_empty_engine_results(root_app, monkeypatch):
+    module, client = root_app
+    module.processes = {"forum": {"status": "running"}}
+    monkeypatch.setattr(module, "check_app_status", lambda: None)
+    post = Mock()
+    monkeypatch.setattr(module.requests, "post", post)
+
+    response = client.post("/api/search", json={"query": "BettaFish"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "query": "BettaFish",
+        "results": {},
+    }
+    post.assert_not_called()


### PR DESCRIPTION
Fixes #630

**cancel_task logic bug:**

When `current_task` matches and gets cancelled, its status changes to `"cancelled"`. Then the code checks `tasks_registry[task_id].status == 'running'` — which is now false, so it falls through to the 404 branch. The user sees an error even though the task was successfully cancelled.

Fix: track whether we performed a cancellation before checking the registry status.

**search endpoint KeyError:**

`api_ports` only maps `insight`, `media`, `query` — but `running_apps` can include `forum`. Added a guard to skip unmapped apps.