### PR TITLE
Fix database URL encoding and clarify Postgres env mapping

### DIFF
--- a/InsightEngine/utils/db.py
+++ b/InsightEngine/utils/db.py
@@ -7,12 +7,11 @@
 """
 
 from __future__ import annotations
-from urllib.parse import quote_plus
-import asyncio
 import os
 from typing import Any, Dict, Iterable, List, Optional, Union
 
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.engine import URL, make_url
 from sqlalchemy import text
 from InsightEngine.utils.config import settings
 
@@ -28,22 +27,55 @@ _engine: Optional[AsyncEngine] = None
 def _build_database_url() -> str:
     dialect: str = (settings.DB_DIALECT or "mysql").lower()
     host: str = settings.DB_HOST or ""
-    port: str = str(settings.DB_PORT or "")
+    port_int: int = settings.DB_PORT
     user: str = settings.DB_USER or ""
     password: str = settings.DB_PASSWORD or ""
     db_name: str = settings.DB_NAME or ""
 
-    if os.getenv("DATABASE_URL"):
-        return os.getenv("DATABASE_URL")  # 直接使用外部提供的完整URL
+    # 如果外部提供了完整的 DATABASE_URL，优先交给 SQLAlchemy 解析后再渲染。
+    # 这能统一处理密码编码、端口、query 等细节。
+    # 若解析失败，直接抛出清晰异常提示用户对特殊字符做 percent-encode。
+    database_url_env = os.getenv("DATABASE_URL")
+    if database_url_env:
+        try:
+            url_obj = make_url(database_url_env)
+            return url_obj.render_as_string(hide_password=False)
+        except Exception as exc:
+            raise ValueError(
+                "环境变量 DATABASE_URL 不是合法的数据库连接 URL（SQLAlchemy 无法解析）。"
+                "如果用户名或密码包含特殊字符，请对 userinfo 部分进行 percent-encode（例如 '@'→'%40'，':'→'%3A'）。"
+                "或者不要使用 DATABASE_URL，改用 DB_USER/DB_PASSWORD/DB_HOST/DB_PORT/DB_NAME 等分字段配置。"
+            ) from exc
 
-    password = quote_plus(password)
-
+    # 使用 SQLAlchemy 的 URL.create 来安全构建连接 URL，避免手动拼接导致的转义/编码问题
     if dialect in ("postgresql", "postgres"):
         # PostgreSQL 使用 asyncpg 驱动
-        return f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{db_name}"
+        url_obj = URL.create(
+            drivername="postgresql+asyncpg",
+            username=user or None,
+            password=password or None,
+            host=host or None,
+            port=port_int,
+            database=db_name or None,
+        )
+        try:
+            return url_obj.render_as_string(hide_password=False)
+        except Exception:
+            return str(url_obj)
 
     # 默认 MySQL 使用 aiomysql 驱动
-    return f"mysql+aiomysql://{user}:{password}@{host}:{port}/{db_name}"
+    url_obj = URL.create(
+        drivername="mysql+aiomysql",
+        username=user or None,
+        password=password or None,
+        host=host or None,
+        port=port_int,
+        database=db_name or None,
+    )
+    try:
+        return url_obj.render_as_string(hide_password=False)
+    except Exception:
+        return str(url_obj)
 
 
 def get_async_engine() -> AsyncEngine:

--- a/InsightEngine/utils/db.py
+++ b/InsightEngine/utils/db.py
@@ -24,6 +24,26 @@ __all__ = [
 _engine: Optional[AsyncEngine] = None
 
 
+def _parse_database_url(database_url: str) -> URL:
+    """Parse an explicit URL and reject clearly unescaped userinfo separators."""
+    try:
+        scheme_separator = database_url.find("://")
+        if scheme_separator < 0:
+            raise ValueError("missing URL scheme separator")
+
+        authority = database_url[scheme_separator + 3 :].split("/", 1)[0]
+        if authority.count("@") > 1:
+            raise ValueError("userinfo contains an unescaped '@' character")
+
+        return make_url(database_url)
+    except Exception as exc:
+        raise ValueError(
+            "环境变量 DATABASE_URL 不是合法的数据库连接 URL。"
+            "如果用户名或密码包含特殊字符，请对 userinfo 部分进行 percent-encode（例如 '@'→'%40'，':'→'%3A'）。"
+            "或者不要使用 DATABASE_URL，改用 DB_USER/DB_PASSWORD/DB_HOST/DB_PORT/DB_NAME 等分字段配置。"
+        ) from exc
+
+
 def _build_database_url() -> str:
     dialect: str = (settings.DB_DIALECT or "mysql").lower()
     host: str = settings.DB_HOST or ""
@@ -33,19 +53,11 @@ def _build_database_url() -> str:
     db_name: str = settings.DB_NAME or ""
 
     # 如果外部提供了完整的 DATABASE_URL，优先交给 SQLAlchemy 解析后再渲染。
-    # 这能统一处理密码编码、端口、query 等细节。
-    # 若解析失败，直接抛出清晰异常提示用户对特殊字符做 percent-encode。
+    # 明显包含多个未转义 @ 的 userinfo 会被拒绝，避免静默解析为错误主机。
     database_url_env = os.getenv("DATABASE_URL")
     if database_url_env:
-        try:
-            url_obj = make_url(database_url_env)
-            return url_obj.render_as_string(hide_password=False)
-        except Exception as exc:
-            raise ValueError(
-                "环境变量 DATABASE_URL 不是合法的数据库连接 URL（SQLAlchemy 无法解析）。"
-                "如果用户名或密码包含特殊字符，请对 userinfo 部分进行 percent-encode（例如 '@'→'%40'，':'→'%3A'）。"
-                "或者不要使用 DATABASE_URL，改用 DB_USER/DB_PASSWORD/DB_HOST/DB_PORT/DB_NAME 等分字段配置。"
-            ) from exc
+        url_obj = _parse_database_url(database_url_env)
+        return url_obj.render_as_string(hide_password=False)
 
     # 使用 SQLAlchemy 的 URL.create 来安全构建连接 URL，避免手动拼接导致的转义/编码问题
     if dialect in ("postgresql", "postgres"):
@@ -100,5 +112,4 @@ async def fetch_all(query: str, params: Optional[Union[Iterable[Any], Dict[str, 
         rows = result.mappings().all()
         # 将 RowMapping 转换为普通字典
         return [dict(row) for row in rows]
-
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,11 @@ services:
     env_file:
       - .env
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-bettafish}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bettafish}
-      POSTGRES_DB: ${POSTGRES_DB:-bettafish}
+      # Postgres 官方镜像只识别 POSTGRES_* 用于初始化；
+      # 而本项目的应用侧读取 DB_*（见 .env）。这里做一次映射，确保两边一致。
+      POSTGRES_USER: ${DB_USER:-bettafish}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-bettafish}
+      POSTGRES_DB: ${DB_NAME:-bettafish}
     ports:
       - "${POSTGRES_PORT:-5444}:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,9 @@ services:
     environment:
       # Postgres 官方镜像只识别 POSTGRES_* 用于初始化；
       # 而本项目的应用侧读取 DB_*（见 .env）。这里做一次映射，确保两边一致。
-      POSTGRES_USER: ${DB_USER:-bettafish}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-bettafish}
-      POSTGRES_DB: ${DB_NAME:-bettafish}
+      POSTGRES_USER: ${DB_USER:-${POSTGRES_USER:-bettafish}}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-${POSTGRES_PASSWORD:-bettafish}}
+      POSTGRES_DB: ${DB_NAME:-${POSTGRES_DB:-bettafish}}
     ports:
       - "${POSTGRES_PORT:-5444}:5432"
     volumes:

--- a/tests/test_insight_database_url.py
+++ b/tests/test_insight_database_url.py
@@ -1,0 +1,85 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from sqlalchemy.engine import make_url
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def db_module(monkeypatch):
+    insight_package = types.ModuleType("InsightEngine")
+    insight_package.__path__ = [str(PROJECT_ROOT / "InsightEngine")]
+    monkeypatch.setitem(sys.modules, "InsightEngine", insight_package)
+
+    utils_package = types.ModuleType("InsightEngine.utils")
+    utils_package.__path__ = [str(PROJECT_ROOT / "InsightEngine" / "utils")]
+    monkeypatch.setitem(sys.modules, "InsightEngine.utils", utils_package)
+
+    config_path = PROJECT_ROOT / "InsightEngine" / "utils" / "config.py"
+    config_spec = importlib.util.spec_from_file_location("InsightEngine.utils.config", config_path)
+    config_module = importlib.util.module_from_spec(config_spec)
+    monkeypatch.setitem(sys.modules, "InsightEngine.utils.config", config_module)
+    config_spec.loader.exec_module(config_module)
+
+    db_path = PROJECT_ROOT / "InsightEngine" / "utils" / "db.py"
+    db_spec = importlib.util.spec_from_file_location("InsightEngine.utils.db", db_path)
+    module = importlib.util.module_from_spec(db_spec)
+    monkeypatch.setitem(sys.modules, "InsightEngine.utils.db", module)
+    db_spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("dialect", "driver"),
+    [("postgresql", "postgresql+asyncpg"), ("mysql", "mysql+aiomysql")],
+)
+def test_split_fields_round_trip_special_characters(db_module, monkeypatch, dialect, driver):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(db_module.settings, "DB_DIALECT", dialect)
+    monkeypatch.setattr(db_module.settings, "DB_HOST", "localhost")
+    monkeypatch.setattr(db_module.settings, "DB_PORT", 5432)
+    monkeypatch.setattr(db_module.settings, "DB_USER", "user@example.com")
+    monkeypatch.setattr(db_module.settings, "DB_PASSWORD", "p@ss:/?#[]")
+    monkeypatch.setattr(db_module.settings, "DB_NAME", "betta/fish")
+
+    parsed = make_url(db_module._build_database_url())
+
+    assert parsed.drivername == driver
+    assert parsed.username == "user@example.com"
+    assert parsed.password == "p@ss:/?#[]"
+    assert parsed.database == "betta/fish"
+
+
+def test_explicit_url_accepts_percent_encoded_password(db_module, monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://user:p%40ss@localhost:5432/bettafish",
+    )
+
+    parsed = make_url(db_module._build_database_url())
+
+    assert parsed.password == "p@ss"
+    assert parsed.host == "localhost"
+
+
+def test_explicit_url_rejects_unescaped_at_in_password(db_module, monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://user:p@ss@localhost:5432/bettafish",
+    )
+
+    with pytest.raises(ValueError, match="percent-encode"):
+        db_module._build_database_url()
+
+
+def test_compose_keeps_legacy_postgres_variable_fallbacks():
+    compose = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    assert "POSTGRES_USER: ${DB_USER:-${POSTGRES_USER:-bettafish}}" in compose
+    assert "POSTGRES_PASSWORD: ${DB_PASSWORD:-${POSTGRES_PASSWORD:-bettafish}}" in compose
+    assert "POSTGRES_DB: ${DB_NAME:-${POSTGRES_DB:-bettafish}}" in compose


### PR DESCRIPTION
**背景**
之前数据库连接在密码包含特殊字符时可能失败，根因是手动拼接连接串/不一致的 URL 编码行为。

**变更**

- 数据库连接 URL 构建改为使用 SQLAlchemy 的 [URL.create(...)](vscode-file://vscode-app/c:/Users/FLDJ/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html)，由库负责对用户名/密码进行正确编码与渲染（适配 MySQL/PG）。
- 当设置了 [DATABASE_URL](vscode-file://vscode-app/c:/Users/FLDJ/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 时，优先交给 SQLAlchemy [make_url()](vscode-file://vscode-app/c:/Users/FLDJ/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 解析；若 [DATABASE_URL](vscode-file://vscode-app/c:/Users/FLDJ/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 本身不是合法 URL（例如 userinfo 未做 percent-encode），则会抛出清晰异常并给出修复指引。

- docker-compose 中 Postgres 初始化变量改为从 DB_* 映射到 POSTGRES_*，确保镜像初始化与应用侧读取同一套配置；宿主机映射端口保持使用 POSTGRES_PORT（默认 5444）避免与应用连接端口 [DB_PORT](vscode-file://vscode-app/c:/Users/FLDJ/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 混淆。