### PR TITLE
feat: add MiniMax as verified LLM provider with M2.7 default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,11 +28,11 @@ DB_DIALECT=postgresql
 # ---- MiniMax 快速配置参考 ----
 # MiniMax 提供 OpenAI 兼容接口，拥有 204K 超大上下文窗口，非常适合深度分析与长文报告生成。
 # 官方申请地址：https://platform.minimax.io/
-# 可选模型：MiniMax-M2.5（推荐）、MiniMax-M2.5-highspeed（更快速）
+# 可选模型：MiniMax-M2.7（推荐）、MiniMax-M2.7-highspeed（更快速）、MiniMax-M2.5、MiniMax-M2.5-highspeed
 # 如需使用 MiniMax 作为某个 Agent 的 LLM，只需将对应 Agent 的配置设为：
 #   XXX_API_KEY=your_minimax_api_key
 #   XXX_BASE_URL=https://api.minimax.io/v1
-#   XXX_MODEL_NAME=MiniMax-M2.5
+#   XXX_MODEL_NAME=MiniMax-M2.7
 # 注意：MiniMax 的 temperature 参数范围为 (0, 1]，不支持设为 0，推荐使用默认值 1.0
 # 国内用户可使用国内域名：https://api.minimaxi.com/v1
 

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,17 @@ DB_DIALECT=postgresql
 # 您可以更改每个部分LLM使用的API，🚩只要兼容OpenAI请求格式都可以，定义好KEY、BASE_URL与MODEL_NAME即可正常使用。
 # 重要提醒：我们强烈推荐您先使用推荐的配置申请API，先跑通再进行您的更改！
 # 我们的LLM模型API赞助商有：https://aihubmix.com/?aff=8Ds9，提供了非常全面的模型api
+#
+# ---- MiniMax 快速配置参考 ----
+# MiniMax 提供 OpenAI 兼容接口，拥有 204K 超大上下文窗口，非常适合深度分析与长文报告生成。
+# 官方申请地址：https://platform.minimax.io/
+# 可选模型：MiniMax-M2.5（推荐）、MiniMax-M2.5-highspeed（更快速）
+# 如需使用 MiniMax 作为某个 Agent 的 LLM，只需将对应 Agent 的配置设为：
+#   XXX_API_KEY=your_minimax_api_key
+#   XXX_BASE_URL=https://api.minimax.io/v1
+#   XXX_MODEL_NAME=MiniMax-M2.5
+# 注意：MiniMax 的 temperature 参数范围为 (0, 1]，不支持设为 0，推荐使用默认值 1.0
+# 国内用户可使用国内域名：https://api.minimaxi.com/v1
 
 # Insight Agent（推荐kimi-k2，官方申请地址：https://platform.moonshot.cn/）
 INSIGHT_ENGINE_API_KEY=

--- a/README-EN.md
+++ b/README-EN.md
@@ -571,13 +571,13 @@ The system supports any LLM provider that follows the OpenAI request format. You
 >```python
 >from openai import OpenAI
 >
->client = OpenAI(api_key="your_api_key", 
+>client = OpenAI(api_key="your_api_key",
 >                base_url="https://aihubmix.com/v1")
 >
 >response = client.chat.completions.create(
 >    model="gpt-4o-mini",
 >    messages=[
->        {'role': 'user', 
+>        {'role': 'user',
 >         'content': "What new opportunities will reasoning models bring to the market?"}
 >    ],
 >)
@@ -585,6 +585,41 @@ The system supports any LLM provider that follows the OpenAI request format. You
 >complete_response = response.choices[0].message.content
 >print(complete_response)
 >```
+
+#### Verified LLM Providers
+
+The following LLM providers have been verified and can be used directly:
+
+| Provider | Recommended Model | Base URL | Sign Up | Highlights |
+|----------|------------------|----------|---------|------------|
+| Kimi (Moonshot) | `kimi-k2-0711-preview` | `https://api.moonshot.cn/v1` | [platform.moonshot.cn](https://platform.moonshot.cn/) | Strong Chinese language understanding |
+| DeepSeek | `deepseek-chat` | `https://api.deepseek.com` | [platform.deepseek.com](https://platform.deepseek.com/) | Cost-effective reasoning model |
+| Gemini (via AIHubMix) | `gemini-2.5-pro` | `https://aihubmix.com/v1` | [aihubmix.com](https://aihubmix.com/?aff=8Ds9) | Powerful multimodal capabilities |
+| Qwen | `qwen-plus` | Per platform | [aliyun.com/bailian](https://www.aliyun.com/product/bailian) | Optimized for Chinese |
+| **MiniMax** | `MiniMax-M2.5` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K ultra-large context window**, ideal for deep analysis & report generation |
+
+<details>
+<summary>Quick Configuration Example for MiniMax</summary>
+
+[MiniMax](https://platform.minimax.io/) provides an OpenAI-compatible API with a 204,800-token ultra-large context window, making it ideal for public opinion analysis scenarios that require processing large volumes of text.
+
+**Available Models:**
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.5` | Flagship model, recommended for Report Agent and deep analysis tasks |
+| `MiniMax-M2.5-highspeed` | High-speed version, suitable for Query Agent and fast-response tasks |
+
+**Configuration Example (using Report Agent as an example):**
+```env
+REPORT_ENGINE_API_KEY=your_minimax_api_key
+REPORT_ENGINE_BASE_URL=https://api.minimax.io/v1
+REPORT_ENGINE_MODEL_NAME=MiniMax-M2.5
+```
+
+> Note: MiniMax's temperature parameter range is (0, 1], zero is not supported. The recommended default is 1.0.
+> Users in mainland China can use the domestic endpoint: `https://api.minimaxi.com/v1`
+
+</details>
 
 ### Change Sentiment Analysis Models
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -596,7 +596,7 @@ The following LLM providers have been verified and can be used directly:
 | DeepSeek | `deepseek-chat` | `https://api.deepseek.com` | [platform.deepseek.com](https://platform.deepseek.com/) | Cost-effective reasoning model |
 | Gemini (via AIHubMix) | `gemini-2.5-pro` | `https://aihubmix.com/v1` | [aihubmix.com](https://aihubmix.com/?aff=8Ds9) | Powerful multimodal capabilities |
 | Qwen | `qwen-plus` | Per platform | [aliyun.com/bailian](https://www.aliyun.com/product/bailian) | Optimized for Chinese |
-| **MiniMax** | `MiniMax-M2.5` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K ultra-large context window**, ideal for deep analysis & report generation |
+| **MiniMax** | `MiniMax-M2.7` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K ultra-large context window**, enhanced reasoning & coding capabilities |
 
 <details>
 <summary>Quick Configuration Example for MiniMax</summary>
@@ -606,14 +606,16 @@ The following LLM providers have been verified and can be used directly:
 **Available Models:**
 | Model | Description |
 |-------|-------------|
-| `MiniMax-M2.5` | Flagship model, recommended for Report Agent and deep analysis tasks |
-| `MiniMax-M2.5-highspeed` | High-speed version, suitable for Query Agent and fast-response tasks |
+| `MiniMax-M2.7` | Latest flagship model with enhanced reasoning & coding, recommended for Report Agent and deep analysis tasks |
+| `MiniMax-M2.7-highspeed` | High-speed version of M2.7, suitable for Query Agent and fast-response tasks |
+| `MiniMax-M2.5` | Previous generation flagship model, still available for all scenarios |
+| `MiniMax-M2.5-highspeed` | Previous generation high-speed version |
 
 **Configuration Example (using Report Agent as an example):**
 ```env
 REPORT_ENGINE_API_KEY=your_minimax_api_key
 REPORT_ENGINE_BASE_URL=https://api.minimax.io/v1
-REPORT_ENGINE_MODEL_NAME=MiniMax-M2.5
+REPORT_ENGINE_MODEL_NAME=MiniMax-M2.7
 ```
 
 > Note: MiniMax's temperature parameter range is (0, 1], zero is not supported. The recommended default is 1.0.

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ SENTIMENT_CONFIG = {
 | DeepSeek | `deepseek-chat` | `https://api.deepseek.com` | [platform.deepseek.com](https://platform.deepseek.com/) | 高性价比推理模型 |
 | Gemini (AIHubMix中转) | `gemini-2.5-pro` | `https://aihubmix.com/v1` | [aihubmix.com](https://aihubmix.com/?aff=8Ds9) | 强大的多模态能力 |
 | Qwen (通义千问) | `qwen-plus` | 按平台配置 | [aliyun.com/bailian](https://www.aliyun.com/product/bailian) | 中文优化 |
-| **MiniMax** | `MiniMax-M2.5` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K 超大上下文**，适合深度分析与报告生成 |
+| **MiniMax** | `MiniMax-M2.7` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K 超大上下文**，增强推理与编码能力 |
 
 <details>
 <summary>使用 MiniMax 的快速配置示例</summary>
@@ -611,14 +611,16 @@ SENTIMENT_CONFIG = {
 **可选模型：**
 | 模型 | 说明 |
 |------|------|
-| `MiniMax-M2.5` | 旗舰模型，推荐用于 Report Agent 等需要深度分析的场景 |
-| `MiniMax-M2.5-highspeed` | 高速版本，适合 Query Agent 等需要快速响应的场景 |
+| `MiniMax-M2.7` | 最新旗舰模型，增强推理与编码能力，推荐用于 Report Agent 等深度分析场景 |
+| `MiniMax-M2.7-highspeed` | M2.7 高速版本，适合 Query Agent 等需要快速响应的场景 |
+| `MiniMax-M2.5` | 上一代旗舰模型，仍可用于各类场景 |
+| `MiniMax-M2.5-highspeed` | 上一代高速版本 |
 
 **配置示例（以 Report Agent 为例）：**
 ```env
 REPORT_ENGINE_API_KEY=your_minimax_api_key
 REPORT_ENGINE_BASE_URL=https://api.minimax.io/v1
-REPORT_ENGINE_MODEL_NAME=MiniMax-M2.5
+REPORT_ENGINE_MODEL_NAME=MiniMax-M2.7
 ```
 
 > 注意：MiniMax 的 temperature 参数范围为 (0, 1]，不支持设为 0，推荐使用默认值 1.0。

--- a/README.md
+++ b/README.md
@@ -576,13 +576,13 @@ SENTIMENT_CONFIG = {
 >```python
 >from openai import OpenAI
 >
->client = OpenAI(api_key="your_api_key", 
+>client = OpenAI(api_key="your_api_key",
 >                base_url="https://aihubmix.com/v1")
 >
 >response = client.chat.completions.create(
 >    model="gpt-4o-mini",
 >    messages=[
->        {'role': 'user', 
+>        {'role': 'user',
 >         'content': "推理模型会给市场带来哪些新的机会"}
 >    ],
 >)
@@ -590,6 +590,41 @@ SENTIMENT_CONFIG = {
 >complete_response = response.choices[0].message.content
 >print(complete_response)
 >```
+
+#### 已验证的 LLM 提供商
+
+以下是经过验证可直接使用的 LLM 提供商：
+
+| 提供商 | 推荐模型 | Base URL | 申请地址 | 特点 |
+|--------|---------|----------|---------|------|
+| Kimi (Moonshot) | `kimi-k2-0711-preview` | `https://api.moonshot.cn/v1` | [platform.moonshot.cn](https://platform.moonshot.cn/) | 强大的中文理解能力 |
+| DeepSeek | `deepseek-chat` | `https://api.deepseek.com` | [platform.deepseek.com](https://platform.deepseek.com/) | 高性价比推理模型 |
+| Gemini (AIHubMix中转) | `gemini-2.5-pro` | `https://aihubmix.com/v1` | [aihubmix.com](https://aihubmix.com/?aff=8Ds9) | 强大的多模态能力 |
+| Qwen (通义千问) | `qwen-plus` | 按平台配置 | [aliyun.com/bailian](https://www.aliyun.com/product/bailian) | 中文优化 |
+| **MiniMax** | `MiniMax-M2.5` | `https://api.minimax.io/v1` | [platform.minimax.io](https://platform.minimax.io/) | **204K 超大上下文**，适合深度分析与报告生成 |
+
+<details>
+<summary>使用 MiniMax 的快速配置示例</summary>
+
+[MiniMax](https://platform.minimax.io/) 提供 OpenAI 兼容接口，拥有 204,800 tokens 超大上下文窗口，非常适合需要处理大量文本的舆情分析场景。
+
+**可选模型：**
+| 模型 | 说明 |
+|------|------|
+| `MiniMax-M2.5` | 旗舰模型，推荐用于 Report Agent 等需要深度分析的场景 |
+| `MiniMax-M2.5-highspeed` | 高速版本，适合 Query Agent 等需要快速响应的场景 |
+
+**配置示例（以 Report Agent 为例）：**
+```env
+REPORT_ENGINE_API_KEY=your_minimax_api_key
+REPORT_ENGINE_BASE_URL=https://api.minimax.io/v1
+REPORT_ENGINE_MODEL_NAME=MiniMax-M2.5
+```
+
+> 注意：MiniMax 的 temperature 参数范围为 (0, 1]，不支持设为 0，推荐使用默认值 1.0。
+> 国内用户可使用国内域名：`https://api.minimaxi.com/v1`
+
+</details>
 
 ### 更改情感分析模型
 

--- a/config.py
+++ b/config.py
@@ -40,7 +40,13 @@ class Settings(BaseSettings):
     
     # ======================= LLM 相关 =======================
     # 我们的LLM模型API赞助商有：https://aihubmix.com/?aff=8Ds9，提供了非常全面的模型api
-    
+    # 支持任何兼容 OpenAI 格式的 LLM 提供商，包括但不限于：
+    #   - Kimi（Moonshot）: https://platform.moonshot.cn/
+    #   - DeepSeek: https://platform.deepseek.com/
+    #   - Gemini（通过中转）: https://aihubmix.com/?aff=8Ds9
+    #   - Qwen（通义千问）: https://www.aliyun.com/product/bailian
+    #   - MiniMax: https://platform.minimax.io/  （204K 超大上下文，适合深度分析与报告生成）
+
     # Insight Agent（推荐Kimi，申请地址：https://platform.moonshot.cn/）
     INSIGHT_ENGINE_API_KEY: Optional[str] = Field(None, description="Insight Agent（推荐 kimi-k2，官方申请地址：https://platform.moonshot.cn/）API 密钥，用于主 LLM。🚩请先按推荐配置申请并跑通，再根据需要调整 KEY、BASE_URL 与 MODEL_NAME。")
     INSIGHT_ENGINE_BASE_URL: Optional[str] = Field("https://api.moonshot.cn/v1", description="Insight Agent LLM BaseUrl，可根据厂商自定义")


### PR DESCRIPTION
## Summary
Add MiniMax as a documented and verified alternative LLM provider for all agents, featuring the latest M2.7 flagship model as the default.

## Changes
- **config.py**: Add MiniMax to the supported providers list
- **.env.example**: Add MiniMax quick-start configuration with M2.7 as recommended model
- **README.md / README-EN.md**: Add verified LLM providers table with MiniMax M2.7, model comparison table, and configuration examples

## Available Models
| Model | Description |
|-------|-------------|
| `MiniMax-M2.7` | Latest flagship model with enhanced reasoning & coding (default) |
| `MiniMax-M2.7-highspeed` | High-speed version of M2.7 for low-latency scenarios |
| `MiniMax-M2.5` | Previous generation flagship model |
| `MiniMax-M2.5-highspeed` | Previous generation high-speed version |

## Why
MiniMax offers an OpenAI-compatible API with a 204K ultra-large context window, making it ideal for deep analysis and long-form report generation. M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Testing
- Documentation verified for accuracy in both Chinese and English
- Configuration examples tested with MiniMax API