### PR TITLE
fix: cancel_task returns 404 after successful cancellation and KeyError for forum in search

### DIFF
--- a/ReportEngine/flask_interface.py
+++ b/ReportEngine/flask_interface.py
@@ -999,6 +999,7 @@ def cancel_task(task_id: str):
 
     try:
         with task_lock:
+            cancelled = False
             if current_task and current_task.task_id == task_id:
                 if current_task.status == "running":
                     current_task.update_status("cancelled", 0, "用户取消任务")
@@ -1006,15 +1007,18 @@ def cancel_task(task_id: str):
                         'message': '任务被用户主动终止',
                         'task': current_task.to_dict(),
                     })
+                    cancelled = True
                 current_task = None
-            task = tasks_registry.get(task_id)
-            if task and task.status == 'running':
-                task.update_status("cancelled", task.progress, "用户取消任务")
-                task.publish_event('cancelled', {
-                    'message': '任务被用户主动终止',
-                    'task': task.to_dict(),
-                })
-
+            if not cancelled:
+                task = tasks_registry.get(task_id)
+                if task and task.status == 'running':
+                    task.update_status("cancelled", task.progress, "用户取消任务")
+                    task.publish_event('cancelled', {
+                        'message': '任务被用户主动终止',
+                        'task': task.to_dict(),
+                    })
+                    cancelled = True
+            if cancelled:
                 return jsonify({
                     'success': True,
                     'message': '任务已取消'

--- a/app.py
+++ b/app.py
@@ -1171,10 +1171,13 @@ def search():
     # 向运行中的应用发送搜索请求
     results = {}
     api_ports = {'insight': 8501, 'media': 8502, 'query': 8503}
-    
+
     for app_name in running_apps:
+        api_port = api_ports.get(app_name)
+        if api_port is None:
+            # forum and other non-Streamlit apps have no searchable API endpoint
+            continue
         try:
-            api_port = api_ports[app_name]
             # 调用Streamlit应用的API端点
             response = requests.post(
                 f"http://localhost:{api_port}/api/search",

--- a/tests/test_cancel_task.py
+++ b/tests/test_cancel_task.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the cancel_task logic fix in ReportEngine/flask_interface.py.
+
+Tests the fix for issue #630: cancel_task returned 404 even after successfully
+cancelling the current running task, because the status check was performed after
+the status had already been updated to 'cancelled'.
+"""
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class MockTask:
+    """Minimal mock of a ReportTask for testing cancel logic."""
+
+    def __init__(self, task_id, status="running"):
+        self.task_id = task_id
+        self.status = status
+        self.progress = 0
+
+    def update_status(self, status, progress, message):
+        self.status = status
+        self.progress = progress
+
+    def publish_event(self, event_type, data):
+        pass
+
+    def to_dict(self):
+        return {"task_id": self.task_id, "status": self.status}
+
+
+class TestCancelTaskLogic(unittest.TestCase):
+    """Test the cancel_task logic extracted from flask_interface.py."""
+
+    def _cancel_task_logic(self, task_id, current_task_ref, tasks_registry):
+        """
+        Replication of the fixed cancel_task logic for isolated unit testing.
+        Returns (success, status_code).
+        """
+        task_lock = threading.Lock()
+        cancelled = False
+
+        with task_lock:
+            current_task = current_task_ref[0]
+            if current_task and current_task.task_id == task_id:
+                if current_task.status == "running":
+                    current_task.update_status("cancelled", 0, "用户取消任务")
+                    current_task.publish_event("cancelled", {
+                        "message": "任务被用户主动终止",
+                        "task": current_task.to_dict(),
+                    })
+                    cancelled = True
+                current_task_ref[0] = None
+
+            if not cancelled:
+                task = tasks_registry.get(task_id)
+                if task and task.status == "running":
+                    task.update_status("cancelled", task.progress, "用户取消任务")
+                    task.publish_event("cancelled", {
+                        "message": "任务被用户主动终止",
+                        "task": task.to_dict(),
+                    })
+                    cancelled = True
+
+        if cancelled:
+            return True, 200
+        else:
+            return False, 404
+
+    def test_cancel_current_running_task_returns_success(self):
+        """Cancelling the active current_task should return 200, not 404 (regression for #630)."""
+        task = MockTask("task-001", status="running")
+        current_task_ref = [task]
+        tasks_registry = {"task-001": task}
+
+        success, code = self._cancel_task_logic("task-001", current_task_ref, tasks_registry)
+
+        self.assertTrue(success)
+        self.assertEqual(code, 200)
+        self.assertEqual(task.status, "cancelled")
+        self.assertIsNone(current_task_ref[0])
+
+    def test_cancel_nonexistent_task_returns_404(self):
+        """Cancelling a task that does not exist should return 404."""
+        current_task_ref = [None]
+        tasks_registry = {}
+
+        success, code = self._cancel_task_logic("task-999", current_task_ref, tasks_registry)
+
+        self.assertFalse(success)
+        self.assertEqual(code, 404)
+
+    def test_cancel_registry_task_not_current(self):
+        """A running task in the registry (but not current) should be cancelled successfully."""
+        task = MockTask("task-002", status="running")
+        current_task_ref = [None]
+        tasks_registry = {"task-002": task}
+
+        success, code = self._cancel_task_logic("task-002", current_task_ref, tasks_registry)
+
+        self.assertTrue(success)
+        self.assertEqual(code, 200)
+        self.assertEqual(task.status, "cancelled")
+
+    def test_cancel_already_completed_task_returns_404(self):
+        """A task that is already completed cannot be cancelled."""
+        task = MockTask("task-003", status="completed")
+        current_task_ref = [None]
+        tasks_registry = {"task-003": task}
+
+        success, code = self._cancel_task_logic("task-003", current_task_ref, tasks_registry)
+
+        self.assertFalse(success)
+        self.assertEqual(code, 404)
+
+    def test_current_task_not_running_still_clears_current(self):
+        """A current_task that is not running should be cleared but not re-cancelled."""
+        task = MockTask("task-004", status="completed")
+        current_task_ref = [task]
+        tasks_registry = {"task-004": task}
+
+        success, code = self._cancel_task_logic("task-004", current_task_ref, tasks_registry)
+
+        # Task was not running so cancellation should fail
+        self.assertFalse(success)
+        self.assertEqual(code, 404)
+        # current_task should still be cleared
+        self.assertIsNone(current_task_ref[0])
+        # Status should remain unchanged
+        self.assertEqual(task.status, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #630

## Problem

Two bugs were reported in issue #630:

**1. `cancel_task` always returns 404 after cancelling the current running task**

When `current_task` matched the given `task_id` and its status was `"running"`:
1. `current_task.update_status("cancelled", ...)` changed the status to `"cancelled"`.
2. `current_task = None` cleared the reference.
3. `task = tasks_registry.get(task_id)` retrieved the same object from the registry.
4. `if task and task.status == 'running'` — failed, because status is now `"cancelled"`.
5. The function fell through to the `else` branch and returned **404**, even though cancellation succeeded.

**2. `KeyError` crash in the search endpoint when `forum` is running**

`api_ports = {'insight': 8501, 'media': 8502, 'query': 8503}` has no `'forum'` key, but `running_apps` is built from all `processes` entries (which includes `'forum'`). The direct dict access `api_ports[app_name]` raised `KeyError` when `forum` was running.

## Solution

**Bug 1:** Introduce a `cancelled` flag. Set it to `True` immediately after cancelling `current_task`, and check it before falling through to the registry lookup. The registry check (`task.status == 'running'`) is only performed when `current_task` was not responsible for the cancellation.

**Bug 2:** Replace `api_ports[app_name]` with `api_ports.get(app_name)`. If the port is `None` (e.g. for `forum`, which has no searchable web API), skip that app with `continue`.

## Testing

Added `tests/test_cancel_task.py` with 5 tests that verify:
- Cancelling the active running `current_task` now returns 200 (regression test for the main bug)
- Non-existent tasks still return 404
- Running tasks in the registry (not current) are cancelled successfully
- Already-completed tasks correctly return 404
- A non-running `current_task` is cleared from the global but not re-cancelled