### PR TITLE
fix: specify utf-8 encoding in subprocess.run() to prevent UnicodeDecodeError on Windows

### DIFF
--- a/MindSpider/main.py
+++ b/MindSpider/main.py
@@ -153,7 +153,8 @@ class MindSpider:
                 [sys.executable, str(init_script)],
                 cwd=self.schema_path,
                 capture_output=True,
-                text=True
+                text=True,
+                encoding='utf-8'
             )
             
             if result.returncode == 0:
@@ -242,6 +243,7 @@ class MindSpider:
                     cmd,
                     capture_output=True,
                     text=True,
+                    encoding='utf-8',
                     timeout=300  # 5分钟超时
                 )
                 if result.returncode == 0:


### PR DESCRIPTION
Fixes #641

## Problem

On Windows, `subprocess.run()` with `text=True` uses the system locale encoding (typically GBK in Chinese Windows environments) to decode subprocess stdout/stderr. When the subprocess outputs UTF-8 encoded content that contains bytes invalid in GBK, a `UnicodeDecodeError` is raised during database initialization:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 7163: illegal multibyte sequence
```

This causes `initialize_database()` to silently fail with `数据库初始化失败: None`.

## Solution

Explicitly pass `encoding='utf-8'` to all `subprocess.run()` calls that use `text=True` in `MindSpider/main.py`:

- `initialize_database()` — runs `init_database.py` and captures its output
- `_install_mediacrawler_dependencies()` — runs pip/uv install commands

## Testing

The fix ensures subprocess output is always decoded as UTF-8 regardless of the Windows system locale, matching the encoding used by the Python scripts being executed.