### PR TITLE
fix: correct default DB_PORT from 3306 to 5432 for postgresql dialect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ PORT=5000
 # ====================== 数据库配置 ======================
 # 数据库主机，例如localhost 或 127.0.0.1
 DB_HOST=your_db_host
-# 数据库端口号，默认为3306
-DB_PORT=3306
+# 数据库端口号，postgresql默认为5432，mysql默认为3306
+DB_PORT=5432
 # 数据库用户名
 DB_USER=your_db_user
 # 数据库密码

--- a/README-EN.md
+++ b/README-EN.md
@@ -380,8 +380,8 @@ Edit the `.env` file and fill in your API keys (you can also choose your own mod
 # ====================== Database Configuration ======================
 # Database host, e.g., localhost or 127.0.0.1
 DB_HOST=your_db_host
-# Database port number, default is 3306
-DB_PORT=3306
+# Database port number, postgresql default is 5432, mysql default is 3306
+DB_PORT=5432
 # Database username
 DB_USER=your_db_user
 # Database password

--- a/README.md
+++ b/README.md
@@ -385,8 +385,8 @@ playwright install chromium
 # ====================== 数据库配置 ======================
 # 数据库主机，例如localhost 或 127.0.0.1
 DB_HOST=your_db_host
-# 数据库端口号，默认为3306
-DB_PORT=3306
+# 数据库端口号，postgresql默认为5432，mysql默认为3306
+DB_PORT=5432
 # 数据库用户名
 DB_USER=your_db_user
 # 数据库密码

--- a/config.py
+++ b/config.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     # ====================== 数据库配置 ======================
     DB_DIALECT: str = Field("postgresql", description="数据库类型，可选 mysql 或 postgresql；请与其他连接信息同时配置")
     DB_HOST: str = Field("your_db_host", description="数据库主机，例如localhost 或 127.0.0.1")
-    DB_PORT: int = Field(3306, description="数据库端口号，默认为3306")
+    DB_PORT: int = Field(5432, description="数据库端口号，postgresql默认为5432，mysql默认为3306")
     DB_USER: str = Field("your_db_user", description="数据库用户名")
     DB_PASSWORD: str = Field("your_db_password", description="数据库密码")
     DB_NAME: str = Field("your_db_name", description="数据库名称")


### PR DESCRIPTION
Fixes #642

## Problem

The default `DB_DIALECT` is `postgresql` in `config.py`, but `DB_PORT` defaults to `3306` (MySQL's port). Users who deploy without explicitly setting `DB_PORT` in their `.env` file will get a connection refused error because PostgreSQL listens on port `5432` by default.

This inconsistency also exists in `.env.example`, `README.md`, and `README-EN.md`, which all show `DB_PORT=3306` right next to `DB_DIALECT=postgresql`.

## Solution

Changed the default `DB_PORT` from `3306` to `5432` in `config.py` and updated all related documentation files (`.env.example`, `README.md`, `README-EN.md`) to use the correct PostgreSQL default port.

Note: Sub-module configs (`InsightEngine/utils/config.py`, `MediaEngine/utils/config.py`, `MindSpider/config.py`) default `DB_DIALECT` to `mysql`, so their `DB_PORT=3306` defaults are intentionally left unchanged.

## Testing

- Verified the changed files are consistent: `DB_DIALECT=postgresql` with `DB_PORT=5432`
- `MindSpider/schema/init_database.py` already has a smart fallback (`port = str(settings.DB_PORT or ("3306" if dialect == "mysql" else "5432"))`) that handles `DB_PORT=0`, but not the incorrect default of `3306`