### PR TITLE
fix: 移除 export_pdf.py 中的硬编码绝对路径，改用动态路径解析

### DIFF
--- a/export_pdf.py
+++ b/export_pdf.py
@@ -8,8 +8,11 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+# 动态获取项目根目录，避免硬编码绝对路径
+PROJECT_ROOT = Path(__file__).resolve().parent
+
 # 添加项目路径到sys.path
-sys.path.insert(0, '/Users/mayiding/Desktop/GitMy/BettaFish')
+sys.path.insert(0, str(PROJECT_ROOT))
 
 def export_pdf(ir_file_path):
     """导出PDF"""
@@ -32,7 +35,7 @@ def export_pdf(ir_file_path):
 
         # 确定输出文件名
         topic = document_ir.get('metadata', {}).get('topic', 'report')
-        output_dir = Path('/Users/mayiding/Desktop/GitMy/BettaFish/final_reports/pdf')
+        output_dir = PROJECT_ROOT / 'final_reports' / 'pdf'
         output_dir.mkdir(parents=True, exist_ok=True)
 
         pdf_filename = f"report_{topic}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
@@ -56,15 +59,20 @@ def export_pdf(ir_file_path):
         return None
 
 if __name__ == "__main__":
-    # 使用最新的报告文件
-    latest_report = "/Users/mayiding/Desktop/GitMy/BettaFish/final_reports/ir/report_ir_人工智能行情发展走势_20251119_235407.json"
+    # 在 final_reports/ir 目录中查找最新的报告文件
+    ir_dir = PROJECT_ROOT / 'final_reports' / 'ir'
 
-    if os.path.exists(latest_report):
-        print("="*50)
-        print("开始导出PDF")
-        print("="*50)
-        result = export_pdf(latest_report)
-        if result:
-            print(f"\n📄 PDF文件已生成: {result}")
+    if ir_dir.exists():
+        ir_files = sorted(ir_dir.glob('*.json'), key=os.path.getmtime, reverse=True)
+        if ir_files:
+            latest_report = str(ir_files[0])
+            print("="*50)
+            print("开始导出PDF")
+            print("="*50)
+            result = export_pdf(latest_report)
+            if result:
+                print(f"\n📄 PDF文件已生成: {result}")
+        else:
+            print(f"❌ 在 {ir_dir} 中未找到报告文件")
     else:
-        print(f"❌ 报告文件不存在: {latest_report}")
+        print(f"❌ 报告目录不存在: {ir_dir}")

--- a/tests/test_export_pdf_paths.py
+++ b/tests/test_export_pdf_paths.py
@@ -1,0 +1,38 @@
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import export_pdf
+
+
+def test_project_root_is_derived_from_script_location():
+    assert export_pdf.PROJECT_ROOT == Path(export_pdf.__file__).resolve().parent
+
+
+def test_export_pdf_writes_to_project_reports_directory(monkeypatch, tmp_path):
+    ir_path = tmp_path / "report.json"
+    ir_path.write_text(json.dumps({"metadata": {"topic": "compatibility"}}), encoding="utf-8")
+
+    class FakeRenderer:
+        def render_to_bytes(self, document_ir, optimize_layout):
+            assert document_ir["metadata"]["topic"] == "compatibility"
+            assert optimize_layout is True
+            return b"%PDF-test"
+
+    report_engine = ModuleType("ReportEngine")
+    report_engine.__path__ = []
+    renderers = ModuleType("ReportEngine.renderers")
+    renderers.__path__ = []
+    pdf_renderer = ModuleType("ReportEngine.renderers.pdf_renderer")
+    pdf_renderer.PDFRenderer = FakeRenderer
+    monkeypatch.setitem(sys.modules, "ReportEngine", report_engine)
+    monkeypatch.setitem(sys.modules, "ReportEngine.renderers", renderers)
+    monkeypatch.setitem(sys.modules, "ReportEngine.renderers.pdf_renderer", pdf_renderer)
+    monkeypatch.setattr(export_pdf, "PROJECT_ROOT", tmp_path)
+
+    result = export_pdf.export_pdf(ir_path)
+
+    output_path = Path(result)
+    assert output_path.parent == tmp_path / "final_reports" / "pdf"
+    assert output_path.read_bytes() == b"%PDF-test"


### PR DESCRIPTION
fix: 移除 export_pdf.py 中的硬编码绝对路径
• 使用  Path(__file__).resolve().parent  动态获取项目根目录
• 移除 3 处对  /Users/mayiding/...  的硬编码引用
• 改进  __main__  入口，自动查找最新报告文