### PR TITLE
docs(readme): fix broken image paths, wrong section reference, and minor typos

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -348,7 +348,7 @@ uv venv --python 3.11 # Create Python 3.11 environment
 
 ### 2. Install System Dependencies for PDF Export (Optional)
 
-This section contains detailed configuration instructions:[Configure the dependencies](./static/Partial%20README%20for%20PDF%20Exporting/README-EN.md)
+This section contains detailed configuration instructions: [Configure the dependencies](./static/Partial%20README%20for%20PDF%20Exporting/README-EN.md)
 
 ### 3. Install Dependencies
 
@@ -376,7 +376,7 @@ Copy the `.env.example` file in the project root directory and rename it to `.en
 
 Edit the `.env` file and fill in your API keys (you can also choose your own models and search proxies; see `.env.example` in the project root directory or `config.py` for details):
 
-```yml
+```bash
 # ====================== Database Configuration ======================
 # Database host, e.g., localhost or 127.0.0.1
 DB_HOST=your_db_host
@@ -430,7 +430,7 @@ python app.py
 
 > Note 1: After a run is terminated, the Streamlit app might not shut down correctly and may still be occupying the port. If this occurs, find the process that is holding the port and kill it.
 
-> Note 2: Data scraping needs to be performed as a separate operation. Please refer to the instructions in section 5.3.
+> Note 2: Data scraping needs to be performed as a separate operation. Please refer to the instructions in section 6.3.
 
 Visit http://localhost:5000 to use the complete system
 
@@ -452,7 +452,7 @@ streamlit run SingleEngineApp/insight_engine_streamlit_app.py --server.port 8501
 This section has detailed configuration documentation: [MindSpider Usage Guide](./MindSpider/README.md)
 
 <div align="center">
-<img src="MindSpider\img\example.png" alt="banner" width="600">
+<img src="MindSpider/img/example.png" alt="banner" width="600">
 
 MindSpider Running Example
 </div>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 **始于舆情，而不止于舆情**。“微舆”的目标，是成为驱动一切业务场景的简洁通用的数据分析引擎。
 
-> 举个例子. 你只需简单修改Agent工具集的api参数与prompt，就可以把他变成一个金融领域的市场分析系统
+> 举个例子. 你只需简单修改Agent工具集的api参数与prompt，就可以把它变成一个金融领域的市场分析系统
 >
 > 附一个比较活跃的L站项目讨论帖：https://linux.do/t/topic/1009280
 >
@@ -381,7 +381,7 @@ playwright install chromium
 
 编辑 `.env` 文件，填入您的API密钥（您也可以选择自己的模型、搜索代理，详情见根目录.env.example文件内或根目录config.py中的说明）：
 
-```yml
+```bash
 # ====================== 数据库配置 ======================
 # 数据库主机，例如localhost 或 127.0.0.1
 DB_HOST=your_db_host
@@ -457,7 +457,7 @@ streamlit run SingleEngineApp/insight_engine_streamlit_app.py --server.port 8501
 这部分有详细的配置文档：[MindSpider使用说明](./MindSpider/README.md)
 
 <div align="center">
-<img src="MindSpider\img\example.png" alt="banner" width="600">
+<img src="MindSpider/img/example.png" alt="banner" width="600">
 
 MindSpider 运行示例
 </div>
@@ -570,7 +570,7 @@ SENTIMENT_CONFIG = {
 
 ### 接入不同的LLM模型
 
-支持任意openAI调用格式的LLM提供商，只需要在/config.py中填写对应的KEY、BASE_URL、MODEL_NAME即可。
+支持任意OpenAI调用格式的LLM提供商，只需要在/config.py中填写对应的KEY、BASE_URL、MODEL_NAME即可。
 
 > 什么是openAI调用格式？下面提供一个简单的例子：
 >```python


### PR DESCRIPTION
中英文 README 的小修复。两个文件，共 8 行改动，无文案/结构/排版风格调整。

## 修复内容

| 位置 | 问题 | 修复 |
|---|---|---|
| `README.md`、`README-EN.md`「6.3 爬虫系统单独使用」 | 图片路径 `MindSpider\img\example.png` 使用反斜杠，GitHub 上无法渲染 | 改为正斜杠 `MindSpider/img/example.png` |
| `README-EN.md`「6.1」Note 2 | 引用了不存在的 `section 5.3`（爬虫章节实际是 6.3） | `section 5.3` → `section 6.3` |
| `README-EN.md`「2. Install System Dependencies for PDF Export」 | 冒号后缺空格 `instructions:[Configure...]`，某些 Markdown 解析器无法识别链接 | 补空格 `instructions: [Configure...]` |
| `README.md`、`README-EN.md`「5. 配置 LLM 与数据库」 `.env` 示例 | 代码块语言标签为 ` ```yml`，但内容是 shell 风格 `KEY=VALUE`，不是 YAML | 改为 ` ```bash` 以获得正确的语法高亮 |
| `README.md`「通用引擎示例」 | 代词错误「把**他**变成」（指代系统，应为「它」） | → 「把**它**变成」 |
| `README.md`「接入不同的 LLM 模型」 | 产品名大小写 `openAI` → `OpenAI` | 同左 |

## 验证

- [x] 改动仅涉及 `README.md` 与 `README-EN.md` 两个文件
- [x] 所有段落、章节标题、列表、徽章、HTML 标签、文案均保持原样
- [x] 修复后 MindSpider 示例图在 GitHub Web 端正常显示