### PR TITLE
fix: handle non-JSON model responses

### DIFF
--- a/ReportEngine/utils/json_parser.py
+++ b/ReportEngine/utils/json_parser.py
@@ -105,8 +105,13 @@ class RobustJSONParser:
         异常:
             JSONParseError: 多种修复策略仍无法解析合法JSON
         """
-        if not raw_text or not raw_text.strip():
-            raise JSONParseError(f"{context_name}返回空内容")
+        if not isinstance(raw_text, str):
+            raise JSONParseError(
+                f"{context_name}返回的不是文本内容: {type(raw_text).__name__}",
+                raw_text=repr(raw_text),
+            )
+        if not raw_text.strip():
+            raise JSONParseError(f"{context_name}返回空内容", raw_text=raw_text)
 
         # 原始文本用于后续日志
         original_text = raw_text
@@ -200,8 +205,12 @@ class RobustJSONParser:
         for pattern in self._THINKING_PATTERNS:
             cleaned = re.sub(pattern, "", cleaned, flags=re.DOTALL | re.IGNORECASE)
 
-        # 优先提取任意位置的```json```包裹内容
-        fenced_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned)
+        # 模型可能先输出其他代码块；显式标记为 JSON 的代码块优先级最高。
+        fenced_match = re.search(
+            r"```json\s*([\s\S]*?)\s*```", cleaned, flags=re.IGNORECASE
+        )
+        if not fenced_match:
+            fenced_match = re.search(r"```\s*([\s\S]*?)\s*```", cleaned)
         if fenced_match:
             cleaned = fenced_match.group(1).strip()
         else:

--- a/tests/test_report_json_parser.py
+++ b/tests/test_report_json_parser.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "ReportEngine" / "utils"))
+
+from json_parser import JSONParseError, RobustJSONParser
+
+
+@pytest.fixture
+def parser():
+    return RobustJSONParser(enable_json_repair=False, enable_llm_repair=False)
+
+
+def test_parses_normal_json_response(parser):
+    assert parser.parse('{"status": "ok"}') == {"status": "ok"}
+
+
+def test_prefers_json_markdown_fence(parser):
+    response = """Model notes:
+```
+This is not JSON.
+```
+```json
+{"status": "ok"}
+```
+"""
+
+    assert parser.parse(response) == {"status": "ok"}
+
+
+@pytest.mark.parametrize("response", ["not JSON", None, {"status": "ok"}])
+def test_invalid_model_response_raises_contextual_error(parser, response):
+    with pytest.raises(JSONParseError, match="模型响应"):
+        parser.parse(response, context_name="模型响应")


### PR DESCRIPTION
## 修改内容
处理模型返回非 JSON 内容时的解析异常。

## 关联 Issue
Fixes #681

## 验证方式
- 使用正常 JSON 响应测试
- 使用 Markdown 代码块包裹的 JSON 测试
- 使用无效响应测试