### PR TITLE
fix: submit Star History updates as pull requests

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -3,20 +3,21 @@ name: Update Star History
 on:
   schedule:
     - cron: '17 3 * * 1'
+      timezone: 'UTC'
   workflow_dispatch:
 permissions:
   contents: read
 
 concurrency:
-  group: bettafish-star-history
+  group: repository-star-history-${{ github.repository_id }}
   cancel-in-progress: false
 
 jobs:
-  update-main:
+  update-default-branch:
     if: >-
       ${{
         github.repository == '666ghj/BettaFish' &&
-        github.ref == 'refs/heads/main' &&
+        github.ref_name == github.event.repository.default_branch &&
         (
           github.event_name == 'schedule' ||
           (
@@ -30,8 +31,11 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
     env:
       GIT_TERMINAL_PROMPT: '0'
+      EXPECTED_REPOSITORY: '666ghj/BettaFish'
+      EXPECTED_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Fetch triggering public commit without credentials
         shell: bash
@@ -40,8 +44,8 @@ jobs:
           GH_TOKEN: ''
         run: |
           set -euo pipefail
-          [[ "$GITHUB_REPOSITORY" == '666ghj/BettaFish' ]]
-          [[ "$GITHUB_REF" == 'refs/heads/main' ]]
+          [[ "${GITHUB_REPOSITORY,,}" == "${EXPECTED_REPOSITORY,,}" ]]
+          [[ "$GITHUB_REF" == "refs/heads/$EXPECTED_DEFAULT_BRANCH" ]]
           git init .
           git remote add origin 'https://github.com/666ghj/BettaFish.git'
           git \
@@ -67,13 +71,18 @@ jobs:
           -v
 
       - name: Fetch aggregate Star count only
+        id: count
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           umask 077
-          output="$RUNNER_TEMP/bettafish-star-count.txt"
+          printf '%s  %s\n' \
+            'acb6067e40acf31701a69e7c1eed17be9794355ea2d473c89608ead249a1e50b' \
+            'scripts/fetch_star_count.py' |
+            sha256sum --check --strict -
+          output="$RUNNER_TEMP/repository-star-count.txt"
           [[ ! -e "$output" && ! -L "$output" ]]
           python3 scripts/fetch_star_count.py > "$output"
           [[ -f "$output" && ! -L "$output" ]]
@@ -81,11 +90,12 @@ jobs:
           mapfile -t lines < "$output"
           (( ${#lines[@]} == 1 ))
           [[ "${lines[0]}" =~ ^[0-9]+$ ]]
+          printf 'value=%s\n' "${lines[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Record scheduled aggregate Star snapshot offline without tokens
         shell: bash
         env:
-          STAR_COUNT_FILE: ${{ runner.temp }}/bettafish-star-count.txt
+          STAR_COUNT_FILE: ${{ runner.temp }}/repository-star-count.txt
           GITHUB_TOKEN: ''
           GH_TOKEN: ''
         run: |
@@ -110,6 +120,9 @@ jobs:
       - name: Commit exact output allowlist
         id: commit
         shell: bash
+        env:
+          GITHUB_TOKEN: ''
+          GH_TOKEN: ''
         run: |
           set -euo pipefail
 
@@ -169,13 +182,20 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git -c commit.gpgsign=false commit \
+          git \
+            -c commit.gpgsign=false \
+            -c core.hooksPath=/dev/null \
+            commit \
             -m 'chore: update star history [skip ci]'
           printf 'created=true\n' >> "$GITHUB_OUTPUT"
 
       - name: Verify one allowlisted commit and unchanged main target
+        id: verify
         if: ${{ steps.commit.outputs.created == 'true' }}
         shell: bash
+        env:
+          GITHUB_TOKEN: ''
+          GH_TOKEN: ''
         run: |
           set -euo pipefail
 
@@ -189,9 +209,12 @@ jobs:
           }
 
           base="$GITHUB_SHA"
-          target_ref='refs/heads/main'
-          [[ "$GITHUB_REPOSITORY" == '666ghj/BettaFish' ]]
-          [[ "$GITHUB_REF" == "$target_ref" ]]
+          target_ref="$GITHUB_REF"
+          [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+          update_branch="automation/star-history/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          [[ "${GITHUB_REPOSITORY,,}" == "${EXPECTED_REPOSITORY,,}" ]]
+          [[ "$GITHUB_REF" == "refs/heads/$EXPECTED_DEFAULT_BRANCH" ]]
           [[ "$(git rev-parse HEAD^)" == "$base" ]]
           [[ "$(git rev-list --count "${base}..HEAD")" == 1 ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
@@ -219,24 +242,51 @@ jobs:
           done < <(git diff-tree --no-commit-id --name-only -r -z HEAD)
           (( count > 0 )) || exit 1
 
-          git fetch --no-tags --depth=1 origin "$target_ref"
+          git \
+            -c credential.helper= \
+            -c http.followRedirects=false \
+            fetch \
+            --no-tags \
+            --depth=1 \
+            origin \
+            "$target_ref"
           [[ "$(git rev-parse FETCH_HEAD)" == "$base" ]] || {
             echo "::error::Target advanced; refusing to rebase or overwrite"
             exit 1
           }
 
-      - name: Push one allowlisted commit with an ephemeral credential
+          if git \
+            -c credential.helper= \
+            -c http.followRedirects=false \
+            ls-remote \
+            --exit-code \
+            --heads \
+            origin \
+            "refs/heads/$update_branch" >/dev/null
+          then
+            echo "::error::Temporary branch already exists"
+            exit 1
+          else
+            status=$?
+            [[ "$status" -eq 2 ]] || exit "$status"
+          fi
+
+          printf 'branch=%s\n' "$update_branch" >> "$GITHUB_OUTPUT"
+          printf 'head=%s\n' "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Publish through a verified pull request with an ephemeral credential
+        id: publish
         if: ${{ steps.commit.outputs.created == 'true' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          UPDATE_BRANCH: ${{ steps.verify.outputs.branch }}
+          EXPECTED_HEAD: ${{ steps.verify.outputs.head }}
+          EXPECTED_STAR_COUNT: ${{ steps.count.outputs.value }}
           GIT_TERMINAL_PROMPT: '0'
-          GIT_TRACE: '0'
-          GIT_TRACE_CURL: '0'
-          GIT_TRACE_PACKET: '0'
-          GIT_CURL_VERBOSE: '0'
         run: |
           set -euo pipefail
+          umask 077
 
           allowed() {
             case "$1" in
@@ -248,8 +298,15 @@ jobs:
           }
 
           base="$GITHUB_SHA"
-          [[ "$GITHUB_REPOSITORY" == '666ghj/BettaFish' ]]
-          [[ "$GITHUB_REF" == 'refs/heads/main' ]]
+          head="$(git rev-parse HEAD)"
+          update_branch="$UPDATE_BRANCH"
+          [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+          [[ "$update_branch" == "automation/star-history/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" ]]
+          [[ "$head" == "$EXPECTED_HEAD" ]]
+          [[ "$EXPECTED_STAR_COUNT" =~ ^[0-9]+$ ]]
+          [[ "${GITHUB_REPOSITORY,,}" == "${EXPECTED_REPOSITORY,,}" ]]
+          [[ "$GITHUB_REF" == "refs/heads/$EXPECTED_DEFAULT_BRANCH" ]]
           [[ "$(git rev-parse HEAD^)" == "$base" ]]
           [[ "$(git rev-list --count "${base}..HEAD")" == 1 ]]
           [[ -z "$(git status --porcelain --untracked-files=all)" ]]
@@ -277,8 +334,52 @@ jobs:
           done < <(git diff-tree --no-commit-id --name-only -r -z HEAD)
           (( count > 0 )) || exit 1
 
+          expected_files="$RUNNER_TEMP/star-history-expected-files-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.txt"
+          pr_files="$RUNNER_TEMP/star-history-pr-files-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.txt"
+          open_prs="$RUNNER_TEMP/star-history-open-prs-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.txt"
+          body_file="$RUNNER_TEMP/star-history-pr-body-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.md"
+          [[ ! -e "$expected_files" && ! -L "$expected_files" ]]
+          [[ ! -e "$pr_files" && ! -L "$pr_files" ]]
+          [[ ! -e "$open_prs" && ! -L "$open_prs" ]]
+          [[ ! -e "$body_file" && ! -L "$body_file" ]]
+          git diff-tree --no-commit-id --name-only -r HEAD |
+            LC_ALL=C sort > "$expected_files"
+          [[ -s "$expected_files" && ! -L "$expected_files" ]]
+          trap '
+            rm -f -- "$expected_files" "$pr_files" "$open_prs" "$body_file"
+            unset GH_TOKEN GITHUB_TOKEN
+            unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+          ' EXIT
+
           [[ -n "$GITHUB_TOKEN" ]]
           [[ "$GITHUB_TOKEN" != *$'\n'* && "$GITHUB_TOKEN" != *$'\r'* ]]
+          command -v gh >/dev/null
+          export GH_TOKEN="$GITHUB_TOKEN"
+
+          gh api --paginate \
+            "repos/$EXPECTED_REPOSITORY/pulls?state=open&base=$EXPECTED_DEFAULT_BRANCH&per_page=100" \
+            --jq '.[] | [.number, .user.login, .head.repo.full_name, .head.ref] | @tsv' \
+            > "$open_prs"
+          [[ -f "$open_prs" && ! -L "$open_prs" ]]
+          while IFS=$'\t' read -r existing_number existing_author existing_repo existing_head; do
+            if [[ \
+              "$existing_number" =~ ^[0-9]+$ &&
+              "$existing_author" == 'github-actions[bot]' &&
+              "${existing_repo,,}" == "${EXPECTED_REPOSITORY,,}" &&
+              "$existing_head" == automation/star-history/*
+            ]]; then
+              echo "::error::An existing automated Star History pull request is still open: #$existing_number"
+              exit 1
+            fi
+          done < "$open_prs"
+
+          current_base="$(
+            gh api \
+              "repos/$EXPECTED_REPOSITORY/git/ref/heads/$EXPECTED_DEFAULT_BRANCH" \
+              --jq '.object.sha'
+          )"
+          [[ "$current_base" == "$base" ]]
+
           encoded="$(
             printf 'x-access-token:%s' "$GITHUB_TOKEN" |
               base64 |
@@ -287,7 +388,113 @@ jobs:
           export GIT_CONFIG_COUNT=1
           export GIT_CONFIG_KEY_0="http.${origin}.extraheader"
           export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $encoded"
-          unset encoded GITHUB_TOKEN
-          trap 'unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0' EXIT
+          unset encoded
 
-          git push --porcelain origin HEAD:refs/heads/main
+          git \
+            -c core.hooksPath=/dev/null \
+            -c credential.helper= \
+            push \
+            --porcelain \
+            origin \
+            "HEAD:refs/heads/$update_branch"
+
+          unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+
+          remote_head="$(
+            gh api \
+              "repos/$EXPECTED_REPOSITORY/git/ref/heads/$update_branch" \
+              --jq '.object.sha'
+          )"
+          [[ "$remote_head" == "$head" ]]
+
+          current_base="$(
+            gh api \
+              "repos/$EXPECTED_REPOSITORY/git/ref/heads/$EXPECTED_DEFAULT_BRANCH" \
+              --jq '.object.sha'
+          )"
+          [[ "$current_base" == "$base" ]]
+
+          {
+            echo 'Automated aggregate Star History refresh.'
+            echo
+            echo 'Please review and merge this pull request manually.'
+            echo
+            printf -- '- Triggering main SHA: `%s`\n' "$base"
+            printf -- '- Generated commit SHA: `%s`\n' "$head"
+            printf -- '- Recorded Star count: `%s`\n' "$EXPECTED_STAR_COUNT"
+            echo '- Allowed files: history JSON plus light and dark SVGs only.'
+          } > "$body_file"
+          [[ -s "$body_file" && ! -L "$body_file" ]]
+
+          create_result="$(
+            gh api --method POST "repos/$EXPECTED_REPOSITORY/pulls" \
+              -f 'title=chore: update Star History' \
+              -f "head=$update_branch" \
+              -f "base=$EXPECTED_DEFAULT_BRANCH" \
+              -f "body=$(<"$body_file")" \
+              --jq '[.number, .html_url] | @tsv'
+          )"
+          IFS=$'\t' read -r pr_number pr_url <<< "$create_result"
+          [[ "$pr_number" =~ ^[0-9]+$ ]]
+          [[ "$pr_url" == "https://github.com/$EXPECTED_REPOSITORY/pull/$pr_number" ]]
+
+          validate_open_pr() {
+            local metadata
+            local pr_state pr_draft pr_base_repo pr_base_ref pr_base_sha
+            local pr_head_repo pr_head_ref pr_head_sha pr_author
+
+            metadata="$(
+              gh api "repos/$EXPECTED_REPOSITORY/pulls/$pr_number" \
+                --jq '[.state, (.draft | tostring), .base.repo.full_name, .base.ref, .base.sha, .head.repo.full_name, .head.ref, .head.sha, .user.login] | @tsv'
+            )"
+            IFS=$'\t' read -r \
+              pr_state pr_draft pr_base_repo pr_base_ref pr_base_sha \
+              pr_head_repo pr_head_ref pr_head_sha pr_author <<< "$metadata"
+            [[ "$pr_state" == "open" ]]
+            [[ "$pr_draft" == "false" ]]
+            [[ "${pr_base_repo,,}" == "${EXPECTED_REPOSITORY,,}" ]]
+            [[ "$pr_base_ref" == "$EXPECTED_DEFAULT_BRANCH" ]]
+            [[ "$pr_base_sha" == "$base" ]]
+            [[ "${pr_head_repo,,}" == "${EXPECTED_REPOSITORY,,}" ]]
+            [[ "$pr_head_ref" == "$update_branch" ]]
+            [[ "$pr_head_sha" == "$head" ]]
+            [[ "$pr_author" == 'github-actions[bot]' ]]
+          }
+
+          validate_open_pr
+          gh api \
+            "repos/$EXPECTED_REPOSITORY/pulls/$pr_number/files?per_page=100" \
+            --jq '.[].filename' |
+            LC_ALL=C sort > "$pr_files"
+          [[ -s "$pr_files" && ! -L "$pr_files" ]]
+          cmp --silent "$expected_files" "$pr_files"
+
+          validate_open_pr
+          remote_head="$(
+            gh api \
+              "repos/$EXPECTED_REPOSITORY/git/ref/heads/$update_branch" \
+              --jq '.object.sha'
+          )"
+          [[ "$remote_head" == "$head" ]]
+
+          current_base="$(
+            gh api \
+              "repos/$EXPECTED_REPOSITORY/git/ref/heads/$EXPECTED_DEFAULT_BRANCH" \
+              --jq '.object.sha'
+          )"
+          [[ "$current_base" == "$base" ]]
+
+          {
+            echo '### Star History pull request'
+            echo
+            printf -- '- Pull request: [#%s](%s)\n' "$pr_number" "$pr_url"
+            printf -- '- Base SHA: `%s`\n' "$base"
+            printf -- '- Head SHA: `%s`\n' "$head"
+            printf -- '- Recorded Star count: `%s`\n' "$EXPECTED_STAR_COUNT"
+            echo '- Merge: manual owner review required'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          printf 'branch=%s\n' "$update_branch" >> "$GITHUB_OUTPUT"
+          printf 'head_sha=%s\n' "$head" >> "$GITHUB_OUTPUT"
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
+          printf 'pr_url=%s\n' "$pr_url" >> "$GITHUB_OUTPUT"

--- a/tests/test_fetch_star_count.py
+++ b/tests/test_fetch_star_count.py
@@ -192,13 +192,29 @@ class FetchStarCountTests(unittest.TestCase):
         )
 
         self.assertIn("cron: '17 3 * * 1'", workflow)
+        self.assertIn("timezone: 'UTC'", workflow)
         self.assertNotIn("cron: '17 3 1,16 * *'", workflow)
         self.assertNotIn("cron: '17 3 * * *'", workflow)
+        trigger_block = workflow.split("\non:\n", 1)[1].split(
+            "\npermissions:\n", 1
+        )[0]
+        self.assertEqual(
+            trigger_block,
+            "  schedule:\n"
+            "    - cron: '17 3 * * 1'\n"
+            "      timezone: 'UTC'\n"
+            "  workflow_dispatch:",
+        )
         self.assertNotIn("due-check:", workflow)
         self.assertNotIn("star_history.py due", workflow)
         self.assertNotIn("inputs.force", workflow)
         self.assertNotIn("actions/checkout", workflow)
         self.assertNotIn("uses:", workflow)
+        self.assertNotIn("\n  pull_request:", workflow)
+        self.assertNotIn("\n  pull_request_target:", workflow)
+        self.assertNotIn("\n  workflow_run:", workflow)
+        self.assertNotIn("secrets.", workflow)
+        self.assertIn("sha256sum --check --strict", workflow)
         self.assertIn("Fetch triggering public commit without credentials", workflow)
         self.assertIn("-c credential.helper=", workflow)
         self.assertIn("-c http.followRedirects=false", workflow)
@@ -221,7 +237,7 @@ class FetchStarCountTests(unittest.TestCase):
             self.assertTrue(
                 step_name.startswith("Fetch aggregate Star count only")
                 or step_name.startswith(
-                    "Push one allowlisted commit with an ephemeral credential"
+                    "Publish through a verified pull request with an ephemeral credential"
                 )
             )
 
@@ -236,6 +252,87 @@ class FetchStarCountTests(unittest.TestCase):
             self.assertIn("GH_TOKEN: ''", section)
             self.assertNotIn("${{ github.token }}", section)
             self.assertIn("--force", section)
+
+    def test_workflow_submits_a_verified_pull_request_for_manual_merge(self):
+        repository = Path(__file__).resolve().parents[1]
+        workflow = (
+            repository / ".github/workflows/update-star-history.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("contents: write", workflow)
+        self.assertIn("pull-requests: write", workflow)
+        self.assertIn("id: count", workflow)
+        self.assertIn("printf 'value=%s\\n' \"${lines[0]}\"", workflow)
+        self.assertIn('[[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ ]]', workflow)
+        self.assertIn('[[ "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]]', workflow)
+        self.assertIn(
+            'update_branch="automation/star-history/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            workflow,
+        )
+        self.assertIn("ls-remote \\", workflow)
+        self.assertIn("--exit-code \\", workflow)
+        self.assertIn("--heads \\", workflow)
+        self.assertIn('"refs/heads/$update_branch" >/dev/null', workflow)
+        self.assertIn('"HEAD:refs/heads/$update_branch"', workflow)
+        self.assertEqual(workflow.count("\n            push \\"), 1)
+        self.assertNotIn('"HEAD:$GITHUB_REF"', workflow)
+        self.assertNotIn("HEAD:refs/heads/main", workflow)
+
+        self.assertIn(
+            'gh api --method POST "repos/$EXPECTED_REPOSITORY/pulls"', workflow
+        )
+        self.assertIn('[[ "$pr_state" == "open" ]]', workflow)
+        self.assertIn('[[ "$pr_draft" == "false" ]]', workflow)
+        self.assertIn(
+            '[[ "${pr_base_repo,,}" == "${EXPECTED_REPOSITORY,,}" ]]', workflow
+        )
+        self.assertIn('[[ "$pr_base_ref" == "$EXPECTED_DEFAULT_BRANCH" ]]', workflow)
+        self.assertIn('[[ "$pr_base_sha" == "$base" ]]', workflow)
+        self.assertIn(
+            '[[ "${pr_head_repo,,}" == "${EXPECTED_REPOSITORY,,}" ]]', workflow
+        )
+        self.assertIn('[[ "$pr_head_ref" == "$update_branch" ]]', workflow)
+        self.assertIn('[[ "$pr_head_sha" == "$head" ]]', workflow)
+        self.assertIn('cmp --silent "$expected_files" "$pr_files"', workflow)
+        self.assertGreaterEqual(workflow.count("          validate_open_pr\n"), 2)
+        self.assertIn("Please review and merge this pull request manually.", workflow)
+        self.assertIn("$GITHUB_STEP_SUMMARY", workflow)
+        self.assertIn("existing automated Star History pull request", workflow)
+        self.assertNotIn("pulls/$pr_number/merge", workflow)
+        self.assertNotIn("gh pr merge", workflow)
+        self.assertNotIn("merge_method=", workflow)
+        self.assertNotIn("pulls/$pr_number/reviews", workflow)
+        self.assertNotIn("git/refs/heads/$update_branch", workflow)
+        self.assertNotIn("Verify published main without tokens", workflow)
+        self.assertNotIn("Delete verified temporary branch", workflow)
+        self.assertNotIn("merged_by", workflow)
+        self.assertNotIn("GIT_TRACE:", workflow)
+        self.assertNotIn("GIT_TRACE_CURL:", workflow)
+        self.assertNotIn("GIT_TRACE_PACKET:", workflow)
+        self.assertNotIn("GIT_CURL_VERBOSE:", workflow)
+
+        duplicate_guard_index = workflow.index(
+            "pulls?state=open&base=$EXPECTED_DEFAULT_BRANCH&per_page=100"
+        )
+        push_index = workflow.index('"HEAD:refs/heads/$update_branch"')
+        create_index = workflow.index(
+            'gh api --method POST "repos/$EXPECTED_REPOSITORY/pulls"'
+        )
+        files_index = workflow.index(
+            '"repos/$EXPECTED_REPOSITORY/pulls/$pr_number/files?per_page=100"'
+        )
+        revalidate_index = workflow.rindex("          validate_open_pr\n")
+        remote_head_index = workflow.rindex(
+            '"repos/$EXPECTED_REPOSITORY/git/ref/heads/$update_branch"'
+        )
+        summary_index = workflow.index("$GITHUB_STEP_SUMMARY")
+        self.assertLess(duplicate_guard_index, push_index)
+        self.assertLess(push_index, create_index)
+        self.assertLess(create_index, files_index)
+        self.assertLess(files_index, summary_index)
+        self.assertLess(files_index, revalidate_index)
+        self.assertLess(revalidate_index, remote_head_index)
+        self.assertLess(remote_head_index, summary_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- stop the Star History workflow from pushing directly to protected `main`
- create and strictly validate a ready pull request for manual owner merge
- prevent duplicate automated Star History PRs and re-check base/head/file invariants before reporting success
- preserve BettaFish's weekly Monday schedule and token-free generation boundary

## Root cause

The July 27 and August 3 scheduled runs completed generation, tests, allowlist, and single-commit validation, then failed with `GH013` because the workflow attempted to push directly to protected `main`.

## Validation

- `python3 -m unittest tests.test_star_history tests.test_fetch_star_count -v` (27 tests)
- `python3 scripts/star_history.py check`
- workflow YAML parse
- `bash -n` for all 8 run blocks
- `git diff --check`
- independent read-only security review: no merge, approval, branch deletion, or main-push path

## Deployment

After this PR is merged, enable the repository setting that allows `GITHUB_TOKEN` to create pull requests and run a manual smoke test. The generated Star History PR will remain open for owner merge.
