### PR TITLE
fix: update Star History twice monthly

### DIFF
--- a/.github/star-history/history.json
+++ b/.github/star-history/history.json
@@ -1,5 +1,5 @@
 {
-  "ongoing_interval_days": 7,
+  "ongoing_interval_days": 13,
   "reconstruction": {
     "daily": [
       {

--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -2,7 +2,7 @@ name: Update Star History
 
 on:
   schedule:
-    - cron: '17 3 * * 1'
+    - cron: '17 3 1,16 * *'
       timezone: 'UTC'
   workflow_dispatch:
 permissions:

--- a/scripts/star_history.py
+++ b/scripts/star_history.py
@@ -31,7 +31,7 @@ from typing import Any, Mapping, Protocol, Sequence
 
 REPOSITORY = "666ghj/BettaFish"
 REPOSITORY_OWNER, REPOSITORY_NAME = REPOSITORY.split("/", 1)
-INTERVAL_DAYS = 7
+INTERVAL_DAYS = 13
 STATE_RELATIVE = Path(".github/star-history/history.json")
 LIGHT_SVG_RELATIVE = Path("static/image/star-history-light.svg")
 DARK_SVG_RELATIVE = Path("static/image/star-history-dark.svg")
@@ -400,7 +400,9 @@ def validate_state(state: Any) -> None:
         state["ongoing_interval_days"] != INTERVAL_DAYS
         or type(state["ongoing_interval_days"]) is not int
     ):
-        raise StarHistoryError("history interval must be exactly 7 days")
+        raise StarHistoryError(
+            f"history interval must be exactly {INTERVAL_DAYS} days"
+        )
 
     reconstruction = state["reconstruction"]
     if not isinstance(reconstruction, dict):
@@ -1400,14 +1402,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("backfill", help="reconstruct history using maintainer access")
-    subparsers.add_parser("due", help="print whether a 7-day snapshot is due")
+    subparsers.add_parser(
+        "due", help=f"print whether a {INTERVAL_DAYS}-day snapshot is due"
+    )
     record = subparsers.add_parser(
         "record", help="apply a fetched aggregate count without GitHub credentials"
     )
     record.add_argument(
         "--count-file", required=True, type=Path, help="file containing one decimal count"
     )
-    record.add_argument("--force", action="store_true", help="record before 7 days")
+    record.add_argument(
+        "--force",
+        action="store_true",
+        help=f"record before {INTERVAL_DAYS} days",
+    )
     subparsers.add_parser("check", help="verify state and deterministic SVG files")
     return parser
 

--- a/tests/test_fetch_star_count.py
+++ b/tests/test_fetch_star_count.py
@@ -191,9 +191,9 @@ class FetchStarCountTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn("cron: '17 3 * * 1'", workflow)
+        self.assertIn("cron: '17 3 1,16 * *'", workflow)
         self.assertIn("timezone: 'UTC'", workflow)
-        self.assertNotIn("cron: '17 3 1,16 * *'", workflow)
+        self.assertNotIn("cron: '17 3 * * 1'", workflow)
         self.assertNotIn("cron: '17 3 * * *'", workflow)
         trigger_block = workflow.split("\non:\n", 1)[1].split(
             "\npermissions:\n", 1
@@ -201,7 +201,7 @@ class FetchStarCountTests(unittest.TestCase):
         self.assertEqual(
             trigger_block,
             "  schedule:\n"
-            "    - cron: '17 3 * * 1'\n"
+            "    - cron: '17 3 1,16 * *'\n"
             "      timezone: 'UTC'\n"
             "  workflow_dispatch:",
         )

--- a/tests/test_star_history.py
+++ b/tests/test_star_history.py
@@ -9,7 +9,7 @@ import unittest
 import xml.etree.ElementTree as ET
 from contextlib import redirect_stderr, redirect_stdout
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -72,7 +72,7 @@ def state_with_snapshots(snapshots=None):
         "schema_version": 1,
         "repository": "666ghj/BettaFish",
         "timezone": "UTC",
-        "ongoing_interval_days": 7,
+        "ongoing_interval_days": 13,
         "reconstruction": {
             "method": "current_stargazers_starred_at",
             "generated_at": "2026-07-01T00:00:00Z",
@@ -256,13 +256,20 @@ class StarHistoryBehaviorTests(unittest.TestCase):
 
             self.assertTrue(state_path.is_symlink())
 
-    def test_due_boundary_is_exactly_seven_days(self):
+    def test_due_boundary_matches_configured_interval(self):
         baseline = state_with_snapshots(
             [{"at": "2026-07-20T05:00:00Z", "stars": 100}]
         )
+        latest = datetime(2026, 7, 20, 5, 0, 0, tzinfo=UTC)
+        boundary = latest + timedelta(days=star_history.INTERVAL_DAYS)
         cases = [
-            ("2026-07-27T04:59:59Z", False),
-            ("2026-07-27T05:00:00Z", True),
+            (
+                (boundary - timedelta(seconds=1)).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                False,
+            ),
+            (boundary.strftime("%Y-%m-%dT%H:%M:%SZ"), True),
         ]
         for now, expected in cases:
             with self.subTest(now=now), tempfile.TemporaryDirectory() as temporary:
@@ -321,10 +328,14 @@ class StarHistoryBehaviorTests(unittest.TestCase):
                 ),
             )
             before = tuple(path.read_bytes() for path in (state_path, light_path, dark_path))
+            latest = datetime(2026, 7, 20, 5, 0, 0, tzinfo=UTC)
+            before_due = latest + timedelta(
+                days=star_history.INTERVAL_DAYS, seconds=-1
+            )
             result = star_history.execute(
                 "record",
                 github=None,
-                clock=FixedClock("2026-07-21T05:00:00Z"),
+                clock=FixedClock(before_due.strftime("%Y-%m-%dT%H:%M:%SZ")),
                 workspace=workspace,
                 star_count=101,
             )
@@ -519,7 +530,7 @@ class StarHistoryBehaviorTests(unittest.TestCase):
             "schema_version": 1,
             "repository": "666ghj/BettaFish",
             "timezone": "UTC",
-            "ongoing_interval_days": 7,
+            "ongoing_interval_days": 13,
             "reconstruction": {
                 "method": "current_stargazers_starred_at",
                 "generated_at": "2026-01-04T00:00:00Z",
@@ -703,7 +714,7 @@ class StarHistoryBehaviorTests(unittest.TestCase):
             "schema_version": 1,
             "repository": "666ghj/BettaFish",
             "timezone": "UTC",
-            "ongoing_interval_days": 7,
+            "ongoing_interval_days": 13,
             "reconstruction": {
                 "method": "current_stargazers_starred_at",
                 "generated_at": "2026-01-02T00:00:00Z",


### PR DESCRIPTION
## Summary

- run Star History on day 1 and 16 at 03:17 UTC
- align the schedule-derived safety interval to 13 days
- keep the protected-main PR publication flow unchanged

## Verification

- python3 scripts/star_history.py check
- python3 -m unittest tests.test_star_history tests.test_fetch_star_count -v
- git diff --check
- workflow YAML parsing and all Bash run-block syntax checks

The existing automated Star History PR #707 was checked for compatibility and can be merged after this cadence change.