### PR TITLE
feat: add OrcaRouter as unified LLM gateway for all engines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,15 @@ KEYWORD_OPTIMIZER_API_KEY=
 KEYWORD_OPTIMIZER_BASE_URL=
 KEYWORD_OPTIMIZER_MODEL_NAME=
 
+# ============== OrcaRouter 统一LLM网关（可选）==============
+# 只需设置 ORCAROUTER_API_KEY，所有 Agent（Insight/Media/Query/Report/MindSpider/论坛主持人/SQL优化器）
+# 的 LLM 调用就会统一走 OrcaRouter（OpenAI兼容网关），一个KEY/端点/模型即可接管全部7处调用，
+# 自动获得自适应路由、自动故障转移、护栏与零信任 Agent 工具治理，无需改动任何 Agent 代码。
+# 申请与文档：https://www.orcarouter.ai  ·  Discord: https://discord.gg/YEubt8enRA
+ORCAROUTER_API_KEY=
+ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+ORCAROUTER_MODEL=orcarouter/auto
+
 # ================== 网络工具配置 ====================
 # Tavily API密钥，用于Tavily网络搜索，申请地址：https://www.tavily.com/
 TAVILY_API_KEY=

--- a/README-EN.md
+++ b/README-EN.md
@@ -315,6 +315,18 @@ Configure the database connection information with the following parameters. The
 
 All LLM calls use the OpenAI API interface standard. After you finish the database configuration, continue to configure **all LLM-related parameters** so the system can connect to your selected LLM service.
 
+**Option A · Per-engine providers (default)**: fill in `{PREFIX}_API_KEY` / `{PREFIX}_BASE_URL` / `{PREFIX}_MODEL_NAME` for each Agent (Insight, Media, Query, Report, MindSpider, Forum Host, SQL Keyword Optimizer — 7 call sites).
+
+**Option B · OrcaRouter unified gateway (optional, recommended)**: add the three variables below to `.env` and all 7 Agents route their LLM calls through [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway — gaining adaptive routing, automatic failover, guardrails and zero-trust agent-tool governance with no Agent code changes:
+
+```bash
+ORCAROUTER_API_KEY=your_orcarouter_key
+ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+ORCAROUTER_MODEL=orcarouter/auto
+```
+
+> Like OpenRouter, OrcaRouter exposes a provider/model namespace over one endpoint; `orcarouter/auto` lets its adaptive router pick the model. When `ORCAROUTER_API_KEY` is set, the per-engine KEY/BASE_URL/MODEL_NAME values are overridden by the gateway config.
+
 Once you complete and save the configurations above, the system will be ready to run normally.
 
 ## 🔧 Source Code Startup Guide
@@ -585,6 +597,8 @@ The system supports any LLM provider that follows the OpenAI request format. You
 >complete_response = response.choices[0].message.content
 >print(complete_response)
 >```
+
+**Integrate the OrcaRouter gateway as a first-class provider**: [OrcaRouter](https://www.orcarouter.ai) also follows the OpenAI request format. Set `ORCAROUTER_API_KEY` in `.env` (default endpoint `https://api.orcarouter.ai/v1`, default model `orcarouter/auto`) and every Agent's LLM calls route through the gateway — no need to treat OrcaRouter as an anonymous custom base URL.
 
 ### Change Sentiment Analysis Models
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,18 @@ docker compose up -d
 
 在完成数据库配置后，请正常配置**所有大模型相关的参数**，确保系统能够连接到您选择的大模型服务。
 
+**方式一 · 各引擎分别配置（默认）**：为每个 Agent 单独填写 `{PREFIX}_API_KEY` / `{PREFIX}_BASE_URL` / `{PREFIX}_MODEL_NAME`（Insight、Media、Query、Report、MindSpider、论坛主持人、SQL优化器共 7 处）。
+
+**方式二 · OrcaRouter 统一网关（可选，推荐）**：只需在 `.env` 中配置以下三项，全部 7 处 Agent 的 LLM 调用即统一走 [OrcaRouter](https://www.orcarouter.ai)（OpenAI 兼容 AI 网关），获得自适应路由、自动故障转移、护栏、零信任 Agent 工具治理等能力，无需改动任何 Agent 代码：
+
+```bash
+ORCAROUTER_API_KEY=你的OrcaRouter密钥
+ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+ORCAROUTER_MODEL=orcarouter/auto
+```
+
+> OrcaRouter 与 OpenRouter 类似，对外暴露统一的 provider/model 命名空间；设置 `ORCAROUTER_MODEL=orcarouter/auto` 时由其自适应路由自动挑选模型。若已配置 `ORCAROUTER_API_KEY`，则各引擎的 KEY、BASE_URL、MODEL_NAME 将被统一覆盖为该网关配置。
+
 完成上述所有配置并保存后，系统即可正常运行。
 
 ## 🔧 源码启动指南
@@ -590,6 +602,8 @@ SENTIMENT_CONFIG = {
 >complete_response = response.choices[0].message.content
 >print(complete_response)
 >```
+
+**统一接入 OrcaRouter 网关**：将 [OrcaRouter](https://www.orcarouter.ai) 作为一等公民 provider 接入时，同样遵循 OpenAI 调用格式——只需在 `.env` 设置 `ORCAROUTER_API_KEY`（默认端点 `https://api.orcarouter.ai/v1`、默认模型 `orcarouter/auto`），所有 Agent 的 LLM 调用便会统一路由到该网关，而无需把 OrcaRouter 当作匿名的自定义 base_url 单独配置。
 
 ### 更改情感分析模型
 

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@
 
 from pathlib import Path
 from pydantic_settings import BaseSettings
-from pydantic import Field, ConfigDict
+from pydantic import Field, ConfigDict, model_validator
 from typing import Optional, Literal
 from loguru import logger
 
@@ -75,7 +75,18 @@ class Settings(BaseSettings):
     KEYWORD_OPTIMIZER_API_KEY: Optional[str] = Field(None, description="SQL Keyword Optimizer（推荐 qwen-plus，官方申请地址：https://www.aliyun.com/product/bailian）API 密钥")
     KEYWORD_OPTIMIZER_BASE_URL: Optional[str] = Field(None, description="Keyword Optimizer BaseUrl，可按所选服务配置")
     KEYWORD_OPTIMIZER_MODEL_NAME: Optional[str] = Field(None, description="Keyword Optimizer LLM 模型名称，例如 qwen-plus")
-    
+
+    # ================== OrcaRouter unified LLM gateway ==================
+    # OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible AI gateway.
+    # Setting ORCAROUTER_API_KEY turns it into a first-class provider for every
+    # engine above: a single key, endpoint and model route all 7 LLM call sites
+    # through OrcaRouter, so adaptive routing, automatic failover, guardrails
+    # and zero-trust agent-tool security apply project-wide without touching any
+    # engine code. Leave ORCAROUTER_API_KEY empty to keep per-engine providers.
+    ORCAROUTER_API_KEY: Optional[str] = Field(None, description="OrcaRouter API key. When set, every engine routes its LLM calls through OrcaRouter with a single key, endpoint and model.")
+    ORCAROUTER_BASE_URL: Optional[str] = Field("https://api.orcarouter.ai/v1", description="OrcaRouter OpenAI-compatible base URL.")
+    ORCAROUTER_MODEL: Optional[str] = Field("orcarouter/auto", description="Model used for all engines when the OrcaRouter gateway is enabled.")
+
     # ================== 网络工具配置 ====================
     # Tavily API（申请地址：https://www.tavily.com/）
     TAVILY_API_KEY: Optional[str] = Field(None, description="Tavily API（申请地址：https://www.tavily.com/）API密钥，用于Tavily网络搜索")
@@ -109,6 +120,36 @@ class Settings(BaseSettings):
         case_sensitive=False,
         extra="allow"
     )
+
+    # All engine LLM configuration pairs, in the order they are exposed as
+    # `{PREFIX}_API_KEY`, `{PREFIX}_BASE_URL` and `{PREFIX}_MODEL_NAME`.
+    _LLM_PROVIDER_PREFIXES = (
+        "INSIGHT_ENGINE",
+        "MEDIA_ENGINE",
+        "QUERY_ENGINE",
+        "REPORT_ENGINE",
+        "MINDSPIDER",
+        "FORUM_HOST",
+        "KEYWORD_OPTIMIZER",
+    )
+
+    @model_validator(mode="after")
+    def _apply_orcarouter_gateway(self) -> "Settings":
+        """
+        When OrcaRouter is enabled, point every engine's LLM calls at it.
+
+        This mirrors how the project already treats each provider (KEY, BASE_URL,
+        MODEL_NAME per engine), but collapses all seven call sites onto a single
+        OpenAI-compatible gateway so OrcaRouter becomes a first-class provider.
+        """
+        if not self.ORCAROUTER_API_KEY:
+            return self
+        for prefix in self._LLM_PROVIDER_PREFIXES:
+            setattr(self, f"{prefix}_API_KEY", self.ORCAROUTER_API_KEY)
+            setattr(self, f"{prefix}_BASE_URL", self.ORCAROUTER_BASE_URL)
+            setattr(self, f"{prefix}_MODEL_NAME", self.ORCAROUTER_MODEL)
+        logger.info("OrcaRouter gateway enabled: all engines will route LLM calls through OrcaRouter.")
+        return self
 
 
 # 创建全局配置实例


### PR DESCRIPTION
This PR adds OrcaRouter as a first-class provider to BettaFish's lightweight, OpenAI-compatible LLM layer. BettaFish already lets each Agent switch providers by filling in KEY/BASE_URL/MODEL_NAME in `config.py` — setting `ORCAROUTER_API_KEY` now collapses all 7 engine call sites (Insight, Media, Query, Report, MindSpider, Forum Host, SQL Keyword Optimizer) onto the [OrcaRouter](https://www.orcarouter.ai) gateway behind a single key, endpoint and model, so its adaptive routing, automatic failover, guardrails and zero-trust agent-tool governance apply project-wide without treating it as an anonymous custom base URL. No existing per-engine config is affected unless the key is set.

Verified:
- `config.py` validator routes all 7 engines to `https://api.orcarouter.ai/v1` / `orcarouter/auto` when enabled; per-engine defaults preserved when disabled
- 94 tests + 42 subtests pass (`pytest tests/`)
- Live L3: real `chat.completions` call through OrcaRouter returned 200

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
I'm an engineer on the OrcaRouter team.
