### PR TITLE
fix: repair sponsor links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,14 +23,14 @@ DB_DIALECT=postgresql
 # ======================= LLM 相关 =======================
 # 您可以更改每个部分LLM使用的API，🚩只要兼容OpenAI请求格式都可以，定义好KEY、BASE_URL与MODEL_NAME即可正常使用。
 # 重要提醒：我们强烈推荐您先使用推荐的配置申请API，先跑通再进行您的更改！
-# 我们的LLM模型API赞助商有：https://aihubmix.com/?aff=8Ds9，提供了非常全面的模型api
+# 我们的LLM模型API赞助商有：https://inferera.com/?aff=8Ds9，提供了非常全面的模型api
 
 # Insight Agent（推荐kimi-k2，官方申请地址：https://platform.moonshot.cn/）
 INSIGHT_ENGINE_API_KEY=
 INSIGHT_ENGINE_BASE_URL=
 INSIGHT_ENGINE_MODEL_NAME=
 
-# Media Agent（推荐gemini-2.5-pro，中转厂商申请地址：https://aihubmix.com/?aff=8Ds9）
+# Media Agent（推荐gemini-2.5-pro，中转厂商申请地址：https://inferera.com/?aff=8Ds9）
 MEDIA_ENGINE_API_KEY=
 MEDIA_ENGINE_BASE_URL=
 MEDIA_ENGINE_MODEL_NAME=
@@ -40,7 +40,7 @@ QUERY_ENGINE_API_KEY=
 QUERY_ENGINE_BASE_URL=
 QUERY_ENGINE_MODEL_NAME=
 
-# Report Agent（推荐gemini-2.5-pro，中转厂商申请地址：https://aihubmix.com/?aff=8Ds9）
+# Report Agent（推荐gemini-2.5-pro，中转厂商申请地址：https://inferera.com/?aff=8Ds9）
 # 注意：Report Agent需要相对较强的模型能力，若最终报告出现图表空白/段落异常的情况，请尝试更换更强的模型
 REPORT_ENGINE_API_KEY=
 REPORT_ENGINE_BASE_URL=

--- a/README-EN.md
+++ b/README-EN.md
@@ -4,7 +4,7 @@
 
 <a href="https://trendshift.io/repositories/15286" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15286" alt="666ghj%2FBettaFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-<a href="https://aihubmix.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>&ensp;
+<a href="https://inferera.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>&ensp;
 <a href="https://open.anspire.cn/?share_code=3E1FUOUH" target="_blank"><img src="./static/image/logo_anspire.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/666ghj/BettaFish?style=flat-square)](https://github.com/666ghj/BettaFish/stargazers)
@@ -69,7 +69,7 @@ Say goodbye to traditional data dashboards. In "WeiYu", everything starts with a
 
 ## 🪄 Sponsors
 
-LLM Model API Sponsor: <a href="https://aihubmix.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
+LLM Model API Sponsor: <a href="https://inferera.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
 
 <details>
 <summary>Provider of core agent capabilities including AI web search, file parsing, and web content scraping: <span style="margin-left: 10px"><a href="https://open.anspire.cn/?share_code=3E1FUOUH" target="_blank"><img src="./static/image/logo_anspire.png" alt="666ghj%2FBettaFish | Trendshift" height="50"/></a></span></summary>
@@ -572,7 +572,7 @@ The system supports any LLM provider that follows the OpenAI request format. You
 >from openai import OpenAI
 >
 >client = OpenAI(api_key="your_api_key", 
->                base_url="https://aihubmix.com/v1")
+>                base_url="https://inferera.com/v1")
 >
 >response = client.chat.completions.create(
 >    model="gpt-4o-mini",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://trendshift.io/repositories/15286" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15286" alt="666ghj%2FBettaFish | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-<a href="https://aihubmix.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>&ensp;
+<a href="https://inferera.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>&ensp;
 <a href="https://open.anspire.cn/?share_code=3E1FUOUH" target="_blank"><img src="./static/image/logo_anspire.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
 
 [![GitHub Stars](https://img.shields.io/github/stars/666ghj/BettaFish?style=flat-square)](https://github.com/666ghj/BettaFish/stargazers)
@@ -70,7 +70,7 @@
 
 ## 🪄 赞助商
 
-LLM模型API赞助：<a href="https://aihubmix.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
+LLM模型API赞助：<a href="https://inferera.com/?aff=8Ds9" target="_blank"><img src="./static/image/logo_aihubmix.png" alt="666ghj%2FBettaFish | Trendshift" height="40"/></a>
 
 <details>
 <summary>AI联网搜索、文件解析及网页内容抓取等智能体核心能力提供商：</a><span style="margin-left: 10px"><a href="https://open.anspire.cn/?share_code=3E1FUOUH" target="_blank"><img src="./static/image/logo_anspire.png" alt="666ghj%2FBettaFish | Trendshift" height="50"/></a></summary>
@@ -577,7 +577,7 @@ SENTIMENT_CONFIG = {
 >from openai import OpenAI
 >
 >client = OpenAI(api_key="your_api_key", 
->                base_url="https://aihubmix.com/v1")
+>                base_url="https://inferera.com/v1")
 >
 >response = client.chat.completions.create(
 >    model="gpt-4o-mini",

--- a/config.py
+++ b/config.py
@@ -39,16 +39,16 @@ class Settings(BaseSettings):
     DB_CHARSET: str = Field("utf8mb4", description="数据库字符集，推荐utf8mb4，兼容emoji")
     
     # ======================= LLM 相关 =======================
-    # 我们的LLM模型API赞助商有：https://aihubmix.com/?aff=8Ds9，提供了非常全面的模型api
+    # 我们的LLM模型API赞助商有：https://inferera.com/?aff=8Ds9，提供了非常全面的模型api
     
     # Insight Agent（推荐Kimi，申请地址：https://platform.moonshot.cn/）
     INSIGHT_ENGINE_API_KEY: Optional[str] = Field(None, description="Insight Agent（推荐 kimi-k2，官方申请地址：https://platform.moonshot.cn/）API 密钥，用于主 LLM。🚩请先按推荐配置申请并跑通，再根据需要调整 KEY、BASE_URL 与 MODEL_NAME。")
     INSIGHT_ENGINE_BASE_URL: Optional[str] = Field("https://api.moonshot.cn/v1", description="Insight Agent LLM BaseUrl，可根据厂商自定义")
     INSIGHT_ENGINE_MODEL_NAME: str = Field("kimi-k2-0711-preview", description="Insight Agent LLM 模型名称，例如 kimi-k2-0711-preview")
     
-    # Media Agent（推荐Gemini，推荐中转厂商：https://aihubmix.com/?aff=8Ds9）
-    MEDIA_ENGINE_API_KEY: Optional[str] = Field(None, description="Media Agent（推荐 gemini-2.5-pro，中转厂商申请地址：https://aihubmix.com/?aff=8Ds9）API 密钥")
-    MEDIA_ENGINE_BASE_URL: Optional[str] = Field("https://aihubmix.com/v1", description="Media Agent LLM BaseUrl，可根据中转服务调整")
+    # Media Agent（推荐Gemini，推荐中转厂商：https://inferera.com/?aff=8Ds9）
+    MEDIA_ENGINE_API_KEY: Optional[str] = Field(None, description="Media Agent（推荐 gemini-2.5-pro，中转厂商申请地址：https://inferera.com/?aff=8Ds9）API 密钥")
+    MEDIA_ENGINE_BASE_URL: Optional[str] = Field("https://inferera.com/v1", description="Media Agent LLM BaseUrl，可根据中转服务调整")
     MEDIA_ENGINE_MODEL_NAME: str = Field("gemini-2.5-pro", description="Media Agent LLM 模型名称，如 gemini-2.5-pro")
     
     # Query Agent（推荐DeepSeek，申请地址：https://www.deepseek.com/）
@@ -56,9 +56,9 @@ class Settings(BaseSettings):
     QUERY_ENGINE_BASE_URL: Optional[str] = Field("https://api.deepseek.com", description="Query Agent LLM BaseUrl")
     QUERY_ENGINE_MODEL_NAME: str = Field("deepseek-chat", description="Query Agent LLM 模型名称，如 deepseek-reasoner")
     
-    # Report Agent（推荐Gemini，推荐中转厂商：https://aihubmix.com/?aff=8Ds9）
-    REPORT_ENGINE_API_KEY: Optional[str] = Field(None, description="Report Agent（推荐 gemini-2.5-pro，中转厂商申请地址：https://aihubmix.com/?aff=8Ds9）API 密钥")
-    REPORT_ENGINE_BASE_URL: Optional[str] = Field("https://aihubmix.com/v1", description="Report Agent LLM BaseUrl，可根据中转服务调整")
+    # Report Agent（推荐Gemini，推荐中转厂商：https://inferera.com/?aff=8Ds9）
+    REPORT_ENGINE_API_KEY: Optional[str] = Field(None, description="Report Agent（推荐 gemini-2.5-pro，中转厂商申请地址：https://inferera.com/?aff=8Ds9）API 密钥")
+    REPORT_ENGINE_BASE_URL: Optional[str] = Field("https://inferera.com/v1", description="Report Agent LLM BaseUrl，可根据中转服务调整")
     REPORT_ENGINE_MODEL_NAME: str = Field("gemini-2.5-pro", description="Report Agent LLM 模型名称，如 gemini-2.5-pro")
 
     # MindSpider Agent（推荐Deepseek，官方申请地址：https://platform.deepseek.com/）


### PR DESCRIPTION
This pull request updates the sponsor referral links and the corresponding OpenAI-compatible API base URLs to the sponsor-provided replacement domain.

Changes:
- Update the Chinese and English README sponsor links and API examples.
- Update the environment example application links.
- Update the Media and Report default base URLs and configuration descriptions.
- Preserve the existing affiliate parameter and `/v1` API path.

Validation:
- The previous domain has zero remaining tracked references.
- The replacement domain appears in exactly 16 expected locations across four files.
- The Media and Report default settings resolve to the replacement `/v1` endpoint under the repository-pinned Pydantic versions.
- `git diff --check` passes.

This pull request was prepared by an automated Agent on behalf of the maintainer.
