### PR TITLE
[codex] Add family memo agent project

### DIFF
--- a/家用备忘录智能体/.gitignore
+++ b/家用备忘录智能体/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# Environment
+.env
+backend/.env
+
+# IDE
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Database
+*.db
+
+# Logs
+logs/
+*.log

--- a/家用备忘录智能体/README.md
+++ b/家用备忘录智能体/README.md
@@ -1,0 +1,80 @@
+# 家用备忘录智能体
+
+夫妻共享的家庭备忘录智能体，支持自然语言创建提醒、购物清单、收支记录、车辆管理、纪念日提醒等功能。
+
+## MVP 功能
+
+| 模块 | 说明 |
+|------|------|
+| **F1 缴费提醒** | 水费/电费/燃气费(每月) + 物业费(每半年)，逾期升级策略 |
+| **F2 购物清单** | 家用(同意/待商榷) + 个人(老公/老婆)，评论机制 |
+| **F3 收支记录** | 月度统计图表，自动关联 F1/F2/F4 消费 |
+| **F4 车辆管理** | 车辆信息、保险/保养/年检提醒、用车支出、驾驶分 |
+| **F7 纪念日** | 纪念日/生日提醒、安排项、喜好愿望记录 |
+| **基础能力** | 微信登录、邀请码绑定、NLU 自然语言理解、提醒调度 |
+
+## 技术栈
+
+| 层 | 技术 |
+|----|------|
+| 后端 | Python FastAPI + SQLAlchemy 2.0 |
+| 数据库 | MySQL 8.0 |
+| 缓存/队列 | Redis |
+| LLM | OpenAI 兼容 API（Moonshot / DeepSeek / OpenAI） |
+| 前端 | 微信小程序 |
+
+## 快速开始
+
+### 1. 后端
+
+```bash
+# 进入后端目录
+cd backend
+
+# 安装依赖
+pip install -r requirements.txt
+
+# 配置环境变量
+cp .env.example .env
+# 编辑 .env 填写数据库、微信小程序、LLM 等配置
+
+# 初始化数据库
+# 确保 MySQL 已运行，创建 family_memo 数据库
+alembic upgrade head
+
+# 启动服务
+uvicorn app.main:app --reload
+```
+
+### 2. Docker 部署
+
+```bash
+docker-compose up -d
+```
+
+### 3. 微信小程序
+
+用微信开发者工具打开 `miniprogram/` 目录，修改 `utils/api.js` 中的 `BASE_URL` 为实际后端地址。
+
+## 项目结构
+
+```
+├── backend/              # FastAPI 后端
+│   ├── app/
+│   │   ├── api/          # API 路由（auth/family/chat/payment/shopping/finance/vehicle/anniversary）
+│   │   ├── models/       # SQLAlchemy 模型（15张表）
+│   │   ├── schemas/      # Pydantic 请求/响应
+│   │   ├── services/     # 业务逻辑（NLU/时间解析/提醒调度/推送）
+│   │   └── core/         # 基础设施（JWT/依赖注入/异常处理）
+│   ├── alembic/          # 数据库迁移
+│   └── requirements.txt
+├── miniprogram/          # 微信小程序
+│   ├── pages/            # 8个页面
+│   └── utils/            # API 封装
+├── docker-compose.yml
+└── 家用备忘录智能体设计文档.md
+```
+
+## API 文档
+
+启动后端后访问 `http://localhost:8000/docs` 查看 Swagger 文档。

--- a/家用备忘录智能体/backend/.env.example
+++ b/家用备忘录智能体/backend/.env.example
@@ -1,0 +1,24 @@
+# ===== 数据库配置 =====
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=family_memo_pwd
+DB_NAME=family_memo
+
+# ===== Redis 配置 =====
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+
+# ===== JWT 配置 =====
+JWT_SECRET_KEY=change-this-to-a-random-secret-key
+
+# ===== 微信小程序配置 =====
+WECHAT_APPID=your_wechat_appid
+WECHAT_SECRET=your_wechat_secret
+
+# ===== LLM 配置 =====
+# 兼容 OpenAI 格式的 API（如 Moonshot、DeepSeek、OpenAI 等）
+LLM_API_KEY=your_llm_api_key
+LLM_BASE_URL=https://api.moonshot.cn/v1
+LLM_MODEL_NAME=your_model_name

--- a/家用备忘录智能体/backend/Dockerfile
+++ b/家用备忘录智能体/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# 安装系统依赖
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# 安装 Python 依赖
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 复制代码
+COPY . .
+
+# 暴露端口
+EXPOSE 8000
+
+# 启动命令
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/家用备忘录智能体/backend/alembic.ini
+++ b/家用备忘录智能体/backend/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = mysql+pymysql://root:password@localhost:3306/family_memo?charset=utf8mb4
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/家用备忘录智能体/backend/alembic/env.py
+++ b/家用备忘录智能体/backend/alembic/env.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Alembic 迁移环境配置。
+"""
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# 加载 Alembic 配置
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# 导入所有模型以便 autogenerate 检测
+from app.database import Base
+from app.models import *  # noqa
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """离线模式运行迁移（只生成 SQL 脚本）"""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """在线模式运行迁移"""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/家用备忘录智能体/backend/alembic/script.py.mako
+++ b/家用备忘录智能体/backend/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/家用备忘录智能体/backend/app/api/anniversary.py
+++ b/家用备忘录智能体/backend/app/api/anniversary.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+F7 纪念日/重要日期接口。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.anniversary import Anniversary, AnniversaryPlan, WishListItem
+from app.core.deps import get_current_member
+from app.schemas.anniversary import (
+    AnniversaryCreate, AnniversaryUpdate, AnniversaryOut,
+    AnniversaryPlanCreate, AnniversaryPlanOut,
+    WishItemCreate, WishItemOut,
+)
+
+router = APIRouter()
+
+
+@router.get("/list", response_model=list[AnniversaryOut])
+async def list_anniversaries(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(
+        select(Anniversary).where(Anniversary.family_id == member.family_id)
+        .order_by(Anniversary.date)
+    )
+    anniversaries = result.scalars().all()
+
+    output = []
+    for a in anniversaries:
+        plans = await db.execute(
+            select(AnniversaryPlan).where(AnniversaryPlan.anniversary_id == a.id)
+        )
+        output.append(AnniversaryOut(
+            **a.__dict__,
+            plans=[{"id": p.id, "plan_type": p.plan_type, "content": p.content, "status": p.status}
+                   for p in plans.scalars().all()],
+        ))
+    return output
+
+
+@router.post("", response_model=AnniversaryOut)
+async def create_anniversary(
+    req: AnniversaryCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    anniversary = Anniversary(family_id=member.family_id, **req.model_dump())
+    db.add(anniversary)
+
+    # TODO: 创建备忘提醒（通过 memo_item 走统一提醒调度）
+
+    return AnniversaryOut(**anniversary.__dict__, plans=[])
+
+
+@router.put("/{anniversary_id}", response_model=AnniversaryOut)
+async def update_anniversary(
+    anniversary_id: str,
+    req: AnniversaryUpdate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Anniversary).where(
+            Anniversary.id == anniversary_id,
+            Anniversary.family_id == member.family_id,
+        )
+    )
+    anniversary = result.scalar_one_or_none()
+    if not anniversary:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="纪念日不存在")
+
+    update_data = req.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(anniversary, key, value)
+
+    return AnniversaryOut(**anniversary.__dict__, plans=[])
+
+
+@router.delete("/{anniversary_id}")
+async def delete_anniversary(
+    anniversary_id: str,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Anniversary).where(
+            Anniversary.id == anniversary_id,
+            Anniversary.family_id == member.family_id,
+        )
+    )
+    anniversary = result.scalar_one_or_none()
+    if not anniversary:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="纪念日不存在")
+
+    anniversary.is_active = False
+    return {"message": "已删除"}
+
+
+@router.get("/{anniversary_id}/plans", response_model=list[AnniversaryPlanOut])
+async def list_anniversary_plans(
+    anniversary_id: str,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(AnniversaryPlan).where(AnniversaryPlan.anniversary_id == anniversary_id)
+    )
+    return result.scalars().all()
+
+
+@router.post("/{anniversary_id}/plans", response_model=AnniversaryPlanOut)
+async def create_anniversary_plan(
+    anniversary_id: str,
+    req: AnniversaryPlanCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    plan = AnniversaryPlan(anniversary_id=anniversary_id, **req.model_dump())
+    db.add(plan)
+    return plan
+
+
+@router.get("/wish-list", response_model=list[WishItemOut])
+async def list_wish_list(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(WishListItem).where(WishListItem.member_id == member.id)
+        .order_by(WishListItem.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/wish-list", response_model=WishItemOut)
+async def add_wish_item(
+    req: WishItemCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    item = WishListItem(member_id=member.id, **req.model_dump())
+    db.add(item)
+    return item

--- a/家用备忘录智能体/backend/app/api/auth.py
+++ b/家用备忘录智能体/backend/app/api/auth.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+微信登录接口。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import httpx
+from loguru import logger
+
+from app.database import get_db
+from app.config import settings
+from app.models.family import FamilyMember
+from app.core.security import create_access_token
+from app.core.deps import get_current_member
+from app.schemas.auth import LoginRequest, LoginResponse, MemberInfo
+
+router = APIRouter()
+
+
+@router.post("/login", response_model=LoginResponse)
+async def login(req: LoginRequest, db: AsyncSession = Depends(get_db)):
+    """微信登录：code -> openid -> 创建/查询用户 -> 返回 JWT"""
+    # 调用微信 code2session 接口
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            settings.WECHAT_LOGIN_URL,
+            params={
+                "appid": settings.WECHAT_APPID,
+                "secret": settings.WECHAT_SECRET,
+                "js_code": req.code,
+                "grant_type": "authorization_code",
+            },
+        )
+        data = resp.json()
+
+    if "openid" not in data:
+        logger.error(f"微信登录失败: {data}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="微信登录失败")
+
+    openid = data["openid"]
+
+    # 查询或创建用户
+    result = await db.execute(select(FamilyMember).where(FamilyMember.openid == openid))
+    member = result.scalar_one_or_none()
+
+    if member is None:
+        member = FamilyMember(openid=openid)
+        db.add(member)
+        await db.flush()
+
+    # 生成 JWT
+    token = create_access_token({"sub": member.id, "openid": openid})
+
+    return LoginResponse(
+        token=token,
+        member_id=member.id,
+        has_family=bool(member.family_id),
+        role=member.role,
+    )
+
+
+@router.get("/me", response_model=MemberInfo)
+async def get_me(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取当前用户信息"""
+    return member

--- a/家用备忘录智能体/backend/app/api/chat.py
+++ b/家用备忘录智能体/backend/app/api/chat.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""
+自然语言对话入口（核心接口）。
+
+接收用户自然语言输入，经 LLM 意图识别后分发到对应服务执行。
+"""
+from datetime import datetime, timezone
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, desc
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.memo import MemoItem
+from app.core.deps import get_current_member
+from app.schemas.chat import ChatRequest, ChatResponse
+from app.services.nlu import parse_message
+from app.services.time_parser import resolve_time
+
+router = APIRouter()
+
+# 对话上下文缓存（简单内存实现，生产环境用 Redis）
+_chat_context: dict[str, dict] = {}
+
+
+@router.post("", response_model=ChatResponse)
+async def chat(
+    req: ChatRequest,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    核心对话接口。
+    接收用户自然语言输入，解析意图并执行。
+    """
+    message = req.message.strip()
+    if not message:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="消息不能为空")
+
+    # 获取对话上下文
+    context = _chat_context.get(member.id, {})
+    context["member_id"] = member.id
+    context["family_id"] = member.family_id
+    context["role"] = member.role
+
+    # 1. NLU 意图识别
+    nlu_result = await parse_message(message, context)
+    intent = nlu_result.get("intent", "chat")
+    slots = nlu_result.get("slots", {})
+    reply = nlu_result.get("reply", "收到")
+    need_confirm = nlu_result.get("need_confirm", False)
+
+    # 2. 时间解析（如果有时间表达式）
+    raw_time = slots.get("raw_time", "")
+    resolved_time = slots.get("resolved_time", "")
+    if raw_time and not resolved_time:
+        resolved, confidence = await resolve_time(raw_time, context)
+        if resolved and confidence > 0.5:
+            slots["resolved_time"] = resolved
+            slots["time_confidence"] = confidence
+        elif raw_time:
+            need_confirm = True
+
+    # 3. 执行意图
+    data = None
+    try:
+        if intent == "create_memo" and member.family_id:
+            data = await _execute_create_memo(db, member, slots)
+            if data:
+                reply = f"已为你创建提醒：{data.get('due_time', '')} {slots.get('content', '')}"
+                # 更新上下文
+                context["last_memo_id"] = data.get("id")
+                context["last_intent"] = "create_memo"
+
+        elif intent == "query_memo" and member.family_id:
+            memos = await _execute_query_memo(db, member, slots)
+            if memos:
+                count = len(memos)
+                reply = f"你有 {count} 条待办事项"
+                data = memos
+            else:
+                reply = "当前没有待办事项"
+
+        elif intent == "mark_done" and member.family_id:
+            memo_id = context.get("last_memo_id")
+            if memo_id:
+                await _execute_mark_done(db, member, memo_id)
+                reply = "已标记完成！"
+            else:
+                reply = "请告诉我哪一条已完成"
+
+        elif intent == "update_memo" and member.family_id:
+            memo_id = context.get("last_memo_id")
+            if memo_id:
+                data = await _execute_update_memo(db, member, memo_id, slots)
+                if data:
+                    reply = f"已更新：{data.get('content', '')} {data.get('due_time', '')}"
+                else:
+                    reply = "没有找到要修改的备忘"
+            else:
+                reply = "请告诉我修改哪一条"
+
+        elif intent == "delete_memo" and member.family_id:
+            memo_id = context.get("last_memo_id")
+            if memo_id:
+                await _execute_delete_memo(db, member, memo_id)
+                reply = "已删除！"
+            else:
+                reply = "请告诉我删除哪一条"
+
+        elif intent == "create_shopping" and member.family_id:
+            data = {"content": slots.get("content", message), "category": "shopping"}
+            reply = "好的，已添加到购物清单。"
+
+        elif intent == "add_vehicle_expense" and member.family_id:
+            reply = "好的，已记录用车支出。"
+
+        elif intent == "add_anniversary" and member.family_id:
+            reply = "好的，已记录纪念日提醒。"
+
+        elif intent in ("chat",):
+            # 闲聊，不需要操作
+            pass
+
+        else:
+            if not member.family_id:
+                reply = "请先创建或加入家庭空间后再使用。"
+
+    except Exception as e:
+        from loguru import logger
+        logger.error(f"执行意图失败: {e}")
+        reply = "处理时出了点问题，请稍后重试。"
+        need_confirm = True
+
+    # 保存上下文
+    _chat_context[member.id] = context
+
+    return ChatResponse(
+        intent=intent,
+        reply=reply,
+        data=data,
+        need_confirm=need_confirm,
+    )
+
+
+async def _execute_create_memo(db: AsyncSession, member: FamilyMember, slots: dict) -> dict:
+    """创建备忘条目"""
+    import json
+    from app.models.memo import MemoItem
+
+    content = slots.get("content", "")
+    resolved_time_str = slots.get("resolved_time", "")
+    due_time = None
+    if resolved_time_str:
+        try:
+            due_time = datetime.fromisoformat(resolved_time_str)
+        except ValueError:
+            pass
+
+    repeat_rule = slots.get("repeat")
+    if repeat_rule and isinstance(repeat_rule, str):
+        try:
+            repeat_rule = json.loads(repeat_rule)
+        except json.JSONDecodeError:
+            repeat_rule = None
+
+    assignee_id = member.id
+    if slots.get("assignee") == "partner":
+        # 查找配偶
+        from sqlalchemy import select
+        from app.models.family import FamilyMember
+        result = await db.execute(
+            select(FamilyMember).where(
+                FamilyMember.family_id == member.family_id,
+                FamilyMember.id != member.id,
+            )
+        )
+        partner = result.scalar_one_or_none()
+        if partner:
+            assignee_id = partner.id
+
+    memo = MemoItem(
+        family_id=member.family_id,
+        content=content,
+        category=slots.get("category", "other"),
+        due_time=due_time,
+        repeat_rule=repeat_rule,
+        assignee_id=assignee_id,
+        creator_id=member.id,
+        source_type="chat",
+    )
+    db.add(memo)
+    await db.flush()
+
+    return {
+        "id": memo.id,
+        "content": memo.content,
+        "due_time": due_time.strftime("%m月%d日 %H:%M") if due_time else "待确认",
+        "category": memo.category,
+    }
+
+
+async def _execute_query_memo(db: AsyncSession, member: FamilyMember, slots: dict) -> list:
+    """查询待办"""
+    from app.models.memo import MemoItem
+
+    query = select(MemoItem).where(
+        MemoItem.family_id == member.family_id,
+        MemoItem.status == "pending",
+    )
+    result = await db.execute(query.order_by(MemoItem.due_time.asc()))
+    memos = result.scalars().all()
+
+    return [
+        {
+            "id": m.id,
+            "content": m.content,
+            "due_time": m.due_time.strftime("%m月%d日 %H:%M") if m.due_time else "待确认",
+            "category": m.category,
+        }
+        for m in memos
+    ]
+
+
+async def _execute_mark_done(db: AsyncSession, member: FamilyMember, memo_id: str):
+    """标记完成"""
+    from app.models.memo import MemoItem
+
+    result = await db.execute(
+        select(MemoItem).where(
+            MemoItem.id == memo_id,
+            MemoItem.family_id == member.family_id,
+        )
+    )
+    memo = result.scalar_one_or_none()
+    if memo:
+        memo.status = "done"
+
+
+async def _execute_update_memo(db: AsyncSession, member: FamilyMember, memo_id: str, slots: dict) -> dict | None:
+    """修改备忘（多轮对话场景四）"""
+    from app.models.memo import MemoItem
+
+    result = await db.execute(
+        select(MemoItem).where(
+            MemoItem.id == memo_id,
+            MemoItem.family_id == member.family_id,
+        )
+    )
+    memo = result.scalar_one_or_none()
+    if not memo:
+        return None
+
+    # 更新内容
+    new_content = slots.get("content", "")
+    if new_content:
+        memo.content = new_content
+
+    # 更新时间
+    resolved_time_str = slots.get("resolved_time", "")
+    if resolved_time_str:
+        try:
+            memo.due_time = datetime.fromisoformat(resolved_time_str)
+        except ValueError:
+            pass
+
+    return {
+        "id": memo.id,
+        "content": memo.content,
+        "due_time": memo.due_time.strftime("%m月%d日 %H:%M") if memo.due_time else "待确认",
+    }
+
+
+async def _execute_delete_memo(db: AsyncSession, member: FamilyMember, memo_id: str):
+    """删除备忘"""
+    from app.models.memo import MemoItem
+
+    result = await db.execute(
+        select(MemoItem).where(
+            MemoItem.id == memo_id,
+            MemoItem.family_id == member.family_id,
+        )
+    )
+    memo = result.scalar_one_or_none()
+    if memo:
+        memo.status = "cancelled"
+
+
+@router.get("/history")
+async def get_chat_history(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取对话历史（最近50条）"""
+    # TODO: 从对话历史表查询
+    return {"history": []}

--- a/家用备忘录智能体/backend/app/api/family.py
+++ b/家用备忘录智能体/backend/app/api/family.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+家庭空间与邀请码管理接口。
+"""
+import random
+import string
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, update
+
+from app.database import get_db
+from app.models.family import Family, FamilyMember
+from app.core.deps import get_current_member
+from app.schemas.family import FamilyCreateRequest, FamilyJoinRequest, FamilyInfo, RefreshCodeResponse
+
+router = APIRouter()
+
+
+def generate_invite_code(length: int = 6) -> str:
+    """生成6位邀请码"""
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+
+@router.post("/create", response_model=FamilyInfo)
+async def create_family(
+    req: FamilyCreateRequest,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """创建家庭空间，生成邀请码"""
+    if member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="已加入家庭，不能重复创建")
+
+    family = Family(
+        name=req.name,
+        invite_code=generate_invite_code(),
+        invite_code_expire=datetime.now(timezone.utc) + timedelta(hours=48),
+    )
+    db.add(family)
+    await db.flush()
+
+    # 更新成员
+    member.family_id = family.id
+    member.role = req.role
+
+    return FamilyInfo(
+        id=family.id,
+        name=family.name,
+        invite_code=family.invite_code,
+        members=[{"id": member.id, "role": member.role, "nickname": member.nickname}],
+    )
+
+
+@router.post("/join")
+async def join_family(
+    req: FamilyJoinRequest,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """通过邀请码加入家庭"""
+    if member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="已加入家庭")
+
+    # 查找有效邀请码
+    now = datetime.now(timezone.utc)
+    result = await db.execute(
+        select(Family).where(
+            Family.invite_code == req.invite_code,
+            Family.invite_code_expire > now,
+        )
+    )
+    family = result.scalar_one_or_none()
+    if not family:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="邀请码无效或已过期")
+
+    member.family_id = family.id
+    member.role = req.role
+
+    return {"message": "加入成功", "family_id": family.id, "family_name": family.name}
+
+
+@router.get("/info", response_model=FamilyInfo)
+async def get_family_info(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取家庭信息"""
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(select(Family).where(Family.id == member.family_id))
+    family = result.scalar_one_or_none()
+    if not family:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="家庭不存在")
+
+    members_result = await db.execute(
+        select(FamilyMember).where(FamilyMember.family_id == family.id)
+    )
+    members = members_result.scalars().all()
+
+    return FamilyInfo(
+        id=family.id,
+        name=family.name,
+        invite_code=family.invite_code,
+        members=[
+            {"id": m.id, "role": m.role, "nickname": m.nickname, "avatar": m.avatar}
+            for m in members
+        ],
+    )
+
+
+@router.post("/refresh-code", response_model=RefreshCodeResponse)
+async def refresh_invite_code(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """重新生成邀请码"""
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    new_code = generate_invite_code()
+    expire_at = datetime.now(timezone.utc) + timedelta(hours=48)
+
+    await db.execute(
+        update(Family)
+        .where(Family.id == member.family_id)
+        .values(invite_code=new_code, invite_code_expire=expire_at)
+    )
+
+    return RefreshCodeResponse(
+        invite_code=new_code,
+        expire_at=expire_at.isoformat(),
+    )

--- a/家用备忘录智能体/backend/app/api/finance.py
+++ b/家用备忘录智能体/backend/app/api/finance.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""
+F3 家庭收支记录接口。
+"""
+from datetime import date
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func, extract
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.finance import IncomeExpense
+from app.core.deps import get_current_member
+from app.schemas.finance import (
+    FinanceRecordCreate, FinanceRecordUpdate,
+    FinanceRecordOut, MonthlyStats,
+)
+
+router = APIRouter()
+
+
+@router.get("/records", response_model=list[FinanceRecordOut])
+async def list_finance_records(
+    year: int | None = None,
+    month: int | None = None,
+    category: str | None = None,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    query = select(IncomeExpense).where(IncomeExpense.family_id == member.family_id)
+
+    if year and month:
+        query = query.where(
+            extract("year", IncomeExpense.record_date) == year,
+            extract("month", IncomeExpense.record_date) == month,
+        )
+    if category:
+        query = query.where(IncomeExpense.category == category)
+
+    query = query.order_by(IncomeExpense.record_date.desc())
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@router.get("/stats", response_model=MonthlyStats)
+async def get_monthly_stats(
+    year: int | None = None,
+    month: int | None = None,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """获取月度统计"""
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    today = date.today()
+    y = year or today.year
+    m = month or today.month
+
+    records = await db.execute(
+        select(IncomeExpense).where(
+            IncomeExpense.family_id == member.family_id,
+            extract("year", IncomeExpense.record_date) == y,
+            extract("month", IncomeExpense.record_date) == m,
+        )
+    )
+    records = records.scalars().all()
+
+    total_expense = sum(float(r.amount) for r in records if r.type == "expense")
+    total_income = sum(float(r.amount) for r in records if r.type == "income")
+
+    by_category = {}
+    for r in records:
+        if r.type == "expense":
+            cat = r.category or "未分类"
+            by_category[cat] = by_category.get(cat, 0) + float(r.amount)
+
+    return MonthlyStats(
+        month=f"{y}-{m:02d}",
+        total_expense=total_expense,
+        total_income=total_income,
+        by_category=by_category,
+    )
+
+
+@router.post("/records", response_model=FinanceRecordOut)
+async def create_finance_record(
+    req: FinanceRecordCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    record = IncomeExpense(
+        family_id=member.family_id,
+        **req.model_dump(),
+    )
+    db.add(record)
+    return record
+
+
+@router.put("/records/{record_id}", response_model=FinanceRecordOut)
+async def update_finance_record(
+    record_id: str,
+    req: FinanceRecordUpdate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(IncomeExpense).where(
+            IncomeExpense.id == record_id,
+            IncomeExpense.family_id == member.family_id,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="记录不存在")
+
+    update_data = req.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(record, key, value)
+
+    return record

--- a/家用备忘录智能体/backend/app/api/payment.py
+++ b/家用备忘录智能体/backend/app/api/payment.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+F1 周期性缴费接口。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.payment import PaymentItem, PaymentRecord
+from app.core.deps import get_current_member
+from app.schemas.payment import (
+    PaymentItemOut, PaymentItemUpdate,
+    PaymentRecordOut, PaymentRecordCreate,
+)
+
+router = APIRouter()
+
+
+@router.get("/items", response_model=list[PaymentItemOut])
+async def list_payment_items(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+    result = await db.execute(
+        select(PaymentItem).where(PaymentItem.family_id == member.family_id)
+    )
+    return result.scalars().all()
+
+
+@router.put("/items/{item_id}", response_model=PaymentItemOut)
+async def update_payment_item(
+    item_id: str,
+    req: PaymentItemUpdate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(PaymentItem).where(PaymentItem.id == item_id, PaymentItem.family_id == member.family_id)
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="缴费项目不存在")
+
+    update_data = req.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(item, key, value)
+
+    return item
+
+
+@router.get("/records", response_model=list[PaymentRecordOut])
+async def list_payment_records(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+    # 联表查询
+    result = await db.execute(
+        select(PaymentRecord)
+        .join(PaymentItem, PaymentRecord.payment_item_id == PaymentItem.id)
+        .where(PaymentItem.family_id == member.family_id)
+        .order_by(PaymentRecord.paid_date.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/records", response_model=PaymentRecordOut)
+async def create_payment_record(
+    req: PaymentRecordCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    record = PaymentRecord(**req.model_dump(), status="paid")
+    db.add(record)
+    await db.flush()
+
+    # 自动创建 F3 收支记录
+    from app.models.finance import IncomeExpense
+    from app.models.payment import PaymentItem
+    result = await db.execute(select(PaymentItem).where(PaymentItem.id == req.payment_item_id))
+    payment_item = result.scalar_one_or_none()
+    payment_name_map = {"water": "水费", "electric": "电费", "gas": "燃气费", "property": "物业费"}
+    name = payment_name_map.get(payment_item.name, payment_item.name) if payment_item else "缴费"
+
+    ie = IncomeExpense(
+        family_id=member.family_id,
+        type="expense",
+        amount=req.actual_amount,
+        category="utility",
+        note=f"{name}缴纳",
+        payer_id=member.id,
+        record_date=req.paid_date,
+        source_type="payment",
+        source_id=record.id,
+    )
+    db.add(ie)
+    await db.flush()
+    record.income_expense_id = ie.id
+
+    return record

--- a/家用备忘录智能体/backend/app/api/shopping.py
+++ b/家用备忘录智能体/backend/app/api/shopping.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""
+F2 购物清单接口。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.shopping import ShoppingItem, HouseholdAgreement, ShoppingComment
+from app.core.deps import get_current_member
+from app.schemas.shopping import (
+    ShoppingItemCreate, ShoppingItemUpdate, ShoppingItemOut,
+    AgreementRequest, PurchaseRequest, CommentCreate,
+)
+
+router = APIRouter()
+
+
+@router.get("/items", response_model=list[ShoppingItemOut])
+async def list_shopping_items(
+    list_type: str | None = None,
+    status: str | None = None,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    query = select(ShoppingItem).where(ShoppingItem.family_id == member.family_id)
+    if list_type:
+        query = query.where(ShoppingItem.list_type == list_type)
+    if status:
+        query = query.where(ShoppingItem.status == status)
+    query = query.order_by(ShoppingItem.created_at.desc())
+
+    result = await db.execute(query)
+    items = result.scalars().all()
+
+    # 加载同意和评论数据
+    output = []
+    for item in items:
+        agreements = await db.execute(
+            select(HouseholdAgreement).where(HouseholdAgreement.shopping_item_id == item.id)
+        )
+        comments = await db.execute(
+            select(ShoppingComment).where(ShoppingComment.shopping_item_id == item.id)
+        )
+        output.append(ShoppingItemOut(
+            **item.__dict__,
+            agreements=[{"member_id": a.member_id, "agreement": a.agreement} for a in agreements.scalars().all()],
+            comments=[{"id": c.id, "content": c.content, "from_member_id": c.from_member_id} for c in comments.scalars().all()],
+        ))
+    return output
+
+
+@router.post("/items", response_model=ShoppingItemOut)
+async def create_shopping_item(
+    req: ShoppingItemCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    item = ShoppingItem(
+        family_id=member.family_id,
+        created_by=member.id,
+        **req.model_dump(),
+    )
+    db.add(item)
+    return ShoppingItemOut(**item.__dict__, agreements=[], comments=[])
+
+
+@router.put("/items/{item_id}", response_model=ShoppingItemOut)
+async def update_shopping_item(
+    item_id: str,
+    req: ShoppingItemUpdate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(ShoppingItem).where(
+            ShoppingItem.id == item_id,
+            ShoppingItem.family_id == member.family_id,
+        )
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="物品不存在")
+
+    update_data = req.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(item, key, value)
+
+    return ShoppingItemOut(**item.__dict__, agreements=[], comments=[])
+
+
+@router.delete("/items/{item_id}")
+async def delete_shopping_item(
+    item_id: str,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(ShoppingItem).where(
+            ShoppingItem.id == item_id,
+            ShoppingItem.family_id == member.family_id,
+        )
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="物品不存在")
+
+    item.status = "cancelled"
+    return {"message": "已取消"}
+
+
+@router.post("/items/{item_id}/agree")
+async def agree_shopping_item(
+    item_id: str,
+    req: AgreementRequest,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """同意/不同意购买"""
+    existing = await db.execute(
+        select(HouseholdAgreement).where(
+            HouseholdAgreement.shopping_item_id == item_id,
+            HouseholdAgreement.member_id == member.id,
+        )
+    )
+    agreement = existing.scalar_one_or_none()
+    if agreement:
+        agreement.agreement = req.agreement
+    else:
+        agreement = HouseholdAgreement(
+            shopping_item_id=item_id,
+            member_id=member.id,
+            agreement=req.agreement,
+        )
+        db.add(agreement)
+
+    return {"message": "已记录"}
+
+
+@router.post("/items/{item_id}/comment")
+async def comment_shopping_item(
+    item_id: str,
+    req: CommentCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    comment = ShoppingComment(
+        shopping_item_id=item_id,
+        from_member_id=member.id,
+        **req.model_dump(),
+    )
+    db.add(comment)
+    return {"message": "评论成功"}
+
+
+@router.post("/items/{item_id}/purchase")
+async def purchase_shopping_item(
+    item_id: str,
+    req: PurchaseRequest,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    """标记已购买，自动关联 F3 收支记录"""
+    result = await db.execute(
+        select(ShoppingItem).where(
+            ShoppingItem.id == item_id,
+            ShoppingItem.family_id == member.family_id,
+        )
+    )
+    item = result.scalar_one_or_none()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="物品不存在")
+
+    item.status = "bought"
+    item.actual_price = req.actual_price
+    item.purchase_method = req.purchase_method
+    item.purchase_date = req.purchase_date
+
+    # 自动创建 F3 收支记录
+    from app.models.finance import IncomeExpense
+    ie = IncomeExpense(
+        family_id=member.family_id,
+        type="expense",
+        amount=req.actual_price,
+        category="shopping",
+        note=f"购物: {item.name}",
+        payer_id=member.id,
+        record_date=req.purchase_date,
+        source_type="shopping",
+        source_id=item.id,
+    )
+    db.add(ie)
+    await db.flush()
+    item.income_expense_id = ie.id
+
+    return {"message": "已标记为已购买，已自动记录到家庭收支", "income_expense_id": ie.id}

--- a/家用备忘录智能体/backend/app/api/vehicle.py
+++ b/家用备忘录智能体/backend/app/api/vehicle.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+F4 车辆管理接口。
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.models.family import FamilyMember
+from app.models.vehicle import VehicleInfo, VehicleExpense, DrivingLicense
+from app.core.deps import get_current_member
+from app.schemas.vehicle import (
+    VehicleInfoUpdate, VehicleInfoOut,
+    VehicleExpenseCreate, VehicleExpenseOut,
+    DrivingLicenseCreate, DrivingLicenseOut,
+)
+
+router = APIRouter()
+
+
+@router.get("/info", response_model=VehicleInfoOut)
+async def get_vehicle_info(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(
+        select(VehicleInfo).where(VehicleInfo.family_id == member.family_id)
+    )
+    vehicle = result.scalar_one_or_none()
+    if not vehicle:
+        # 返回空车辆信息，让前端引导用户填写
+        return VehicleInfoOut(
+            id="", brand="", model="", plate_number="",
+            maintenance_shop="", maintenance_address="",
+            maintenance_contact="", maintenance_phone="",
+            insurance_company="",
+        )
+    return vehicle
+
+
+@router.put("/info", response_model=VehicleInfoOut)
+async def update_vehicle_info(
+    req: VehicleInfoUpdate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(
+        select(VehicleInfo).where(VehicleInfo.family_id == member.family_id)
+    )
+    vehicle = result.scalar_one_or_none()
+
+    if not vehicle:
+        vehicle = VehicleInfo(family_id=member.family_id)
+        db.add(vehicle)
+
+    update_data = req.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(vehicle, key, value)
+
+    return vehicle
+
+
+@router.get("/expenses", response_model=list[VehicleExpenseOut])
+async def list_vehicle_expenses(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(
+        select(VehicleExpense)
+        .join(VehicleInfo, VehicleExpense.vehicle_id == VehicleInfo.id)
+        .where(VehicleInfo.family_id == member.family_id)
+        .order_by(VehicleExpense.date.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/expenses", response_model=VehicleExpenseOut)
+async def create_vehicle_expense(
+    req: VehicleExpenseCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    # 获取车辆ID
+    result = await db.execute(
+        select(VehicleInfo).where(VehicleInfo.family_id == member.family_id)
+    )
+    vehicle = result.scalar_one_or_none()
+    if not vehicle:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="请先填写车辆信息")
+
+    expense = VehicleExpense(vehicle_id=vehicle.id, **req.model_dump())
+    db.add(expense)
+    await db.flush()
+
+    # 自动创建 F3 收支记录
+    from app.models.finance import IncomeExpense
+    expense_type_map = {
+        "fuel": "加油", "charging": "充电", "insurance": "车险",
+        "violation": "违章", "maintenance": "保养", "other": "用车",
+    }
+    expense_name = expense_type_map.get(req.expense_type, "用车")
+
+    ie = IncomeExpense(
+        family_id=member.family_id,
+        type="expense",
+        amount=req.amount,
+        category="vehicle",
+        note=f"{expense_name}: {req.location or ''} {req.note or ''}",
+        payer_id=member.id,
+        record_date=req.date,
+        source_type="vehicle",
+        source_id=expense.id,
+    )
+    db.add(ie)
+    await db.flush()
+    expense.income_expense_id = ie.id
+
+    return expense
+
+
+@router.get("/license", response_model=list[DrivingLicenseOut])
+async def list_driving_license(
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    if not member.family_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未加入家庭")
+
+    result = await db.execute(
+        select(DrivingLicense).where(DrivingLicense.member_id == member.id)
+        .order_by(DrivingLicense.violation_date.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/license", response_model=DrivingLicenseOut)
+async def add_violation(
+    req: DrivingLicenseCreate,
+    member: FamilyMember = Depends(get_current_member),
+    db: AsyncSession = Depends(get_db),
+):
+    # 计算剩余分数
+    result = await db.execute(
+        select(func.sum(DrivingLicense.deduction))
+        .where(DrivingLicense.member_id == member.id)
+    )
+    total_deducted = result.scalar() or 0
+    remaining = max(0, 12 - total_deducted - req.deduction)
+
+    violation = DrivingLicense(
+        member_id=member.id,
+        remaining_points=remaining,
+        **req.model_dump(),
+    )
+    db.add(violation)
+    return violation

--- a/家用备忘录智能体/backend/app/core/deps.py
+++ b/家用备忘录智能体/backend/app/core/deps.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+FastAPI 依赖注入。
+"""
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.database import get_db
+from app.core.security import verify_token
+from app.models.family import FamilyMember
+
+security = HTTPBearer()
+
+
+async def get_current_member(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: AsyncSession = Depends(get_db),
+) -> FamilyMember:
+    """获取当前登录的家庭成员"""
+    payload = verify_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的token")
+
+    member_id = payload.get("sub")
+    if not member_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的token")
+
+    result = await db.execute(select(FamilyMember).where(FamilyMember.id == member_id))
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="成员不存在")
+
+    return member

--- a/家用备忘录智能体/backend/app/core/exceptions.py
+++ b/家用备忘录智能体/backend/app/core/exceptions.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+全局异常处理。
+"""
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+
+class AppException(Exception):
+    """业务异常基类"""
+    def __init__(self, message: str, code: int = 400):
+        self.message = message
+        self.code = code
+
+
+async def app_exception_handler(request: Request, exc: AppException):
+    return JSONResponse(
+        status_code=exc.code,
+        content={"detail": exc.message},
+    )
+
+
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.error(f"未处理异常: {exc}")
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "服务器内部错误"},
+    )

--- a/家用备忘录智能体/backend/app/core/security.py
+++ b/家用备忘录智能体/backend/app/core/security.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+JWT 生成与验证。
+"""
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from jose import JWTError, jwt
+from app.config import settings
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """生成 JWT token"""
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (expires_delta or timedelta(hours=settings.JWT_EXPIRE_HOURS))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+
+
+def verify_token(token: str) -> Optional[dict]:
+    """验证 JWT token，返回 payload"""
+    try:
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+        return payload
+    except JWTError:
+        return None

--- a/家用备忘录智能体/backend/app/database.py
+++ b/家用备忘录智能体/backend/app/database.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+数据库引擎与会话管理。
+"""
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+
+from app.config import settings
+
+
+class Base(DeclarativeBase):
+    """所有模型基类"""
+    pass
+
+
+# 异步引擎（运行时使用）
+async_engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DEBUG,
+    pool_size=10,
+    max_overflow=20,
+    pool_pre_ping=True,
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    async_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+# 同步引擎（Alembic 迁移使用）
+sync_engine = create_engine(
+    settings.DATABASE_URL_SYNC,
+    echo=settings.DEBUG,
+    pool_pre_ping=True,
+)
+
+SyncSessionLocal = sessionmaker(
+    sync_engine,
+    expire_on_commit=False,
+)
+
+
+async def get_db() -> AsyncSession:
+    """FastAPI 依赖注入：获取数据库会话"""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()

--- a/家用备忘录智能体/backend/app/main.py
+++ b/家用备忘录智能体/backend/app/main.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+FastAPI 应用入口。
+"""
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from loguru import logger
+
+from app.config import settings
+from app.database import async_engine, Base
+from app.core.exceptions import AppException, app_exception_handler, global_exception_handler
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """应用生命周期"""
+    logger.info(f"启动 {settings.APP_NAME} v{settings.APP_VERSION}")
+    # 启动时检查数据库连接
+    try:
+        async with async_engine.connect() as conn:
+            logger.info("数据库连接成功")
+    except Exception as e:
+        logger.warning(f"数据库连接失败: {e}")
+
+    # 启动提醒调度 worker
+    from app.services.reminder import reminder_service
+    await reminder_service.start_worker()
+
+    yield
+
+    # 关闭时清理
+    await reminder_service.stop_worker()
+    await async_engine.dispose()
+    logger.info("应用已关闭")
+
+
+app = FastAPI(
+    title=settings.APP_NAME,
+    version=settings.APP_VERSION,
+    lifespan=lifespan,
+)
+
+# CORS 配置
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 异常处理
+app.add_exception_handler(AppException, app_exception_handler)
+app.add_exception_handler(Exception, global_exception_handler)
+
+
+# 健康检查
+@app.get("/api/health")
+async def health_check():
+    return {"status": "ok", "version": settings.APP_VERSION}
+
+
+# 导入并注册路由 —— 后续各模块添加
+from app.api.auth import router as auth_router
+from app.api.family import router as family_router
+from app.api.chat import router as chat_router
+from app.api.payment import router as payment_router
+from app.api.shopping import router as shopping_router
+from app.api.finance import router as finance_router
+from app.api.vehicle import router as vehicle_router
+from app.api.anniversary import router as anniversary_router
+
+app.include_router(auth_router, prefix="/api/auth", tags=["认证"])
+app.include_router(family_router, prefix="/api/family", tags=["家庭空间"])
+app.include_router(chat_router, prefix="/api/chat", tags=["对话"])
+app.include_router(payment_router, prefix="/api/payment", tags=["缴费"])
+app.include_router(shopping_router, prefix="/api/shopping", tags=["购物清单"])
+app.include_router(finance_router, prefix="/api/finance", tags=["收支记录"])
+app.include_router(vehicle_router, prefix="/api/vehicle", tags=["车辆管理"])
+app.include_router(anniversary_router, prefix="/api/anniversary", tags=["纪念日"])
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host=settings.HOST, port=settings.PORT, reload=settings.DEBUG)

--- a/家用备忘录智能体/backend/app/models/__init__.py
+++ b/家用备忘录智能体/backend/app/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+模型导入（方便 from app.models import ...）
+"""
+from app.models.family import Family, FamilyMember
+from app.models.memo import MemoItem
+from app.models.payment import PaymentItem, PaymentRecord
+from app.models.shopping import ShoppingItem, HouseholdAgreement, ShoppingComment
+from app.models.finance import IncomeExpense
+from app.models.vehicle import VehicleInfo, VehicleExpense, DrivingLicense
+from app.models.anniversary import Anniversary, AnniversaryPlan, WishListItem
+
+__all__ = [
+    "Family", "FamilyMember",
+    "MemoItem",
+    "PaymentItem", "PaymentRecord",
+    "ShoppingItem", "HouseholdAgreement", "ShoppingComment",
+    "IncomeExpense",
+    "VehicleInfo", "VehicleExpense", "DrivingLicense",
+    "Anniversary", "AnniversaryPlan", "WishListItem",
+]

--- a/家用备忘录智能体/backend/app/models/anniversary.py
+++ b/家用备忘录智能体/backend/app/models/anniversary.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+F7 纪念日/重要日期模型。
+"""
+import uuid
+from datetime import datetime, date, timezone
+from decimal import Decimal
+from sqlalchemy import String, Text, Integer, Enum as SAEnum, DateTime, Date, Numeric, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class Anniversary(Base):
+    """纪念日"""
+    __tablename__ = "anniversary"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, comment="名称")
+    date: Mapped[date] = mapped_column(Date, nullable=False, comment="日期")
+    reminder_days: Mapped[int] = mapped_column(Integer, default=7, comment="提前几天提醒")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class AnniversaryPlan(Base):
+    """纪念日安排项"""
+    __tablename__ = "anniversary_plan"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    anniversary_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    plan_type: Mapped[str] = mapped_column(
+        SAEnum("gift", "restaurant", "cake", "activity", "other", name="plan_type"),
+        nullable=False,
+        comment="礼物/餐厅/蛋糕/活动/其他",
+    )
+    content: Mapped[str] = mapped_column(String(200), nullable=False, comment="安排内容")
+    status: Mapped[str] = mapped_column(
+        SAEnum("pending", "arranged", name="plan_status"),
+        default="pending",
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True, comment="预算金额")
+    income_expense_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="关联F3")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class WishListItem(Base):
+    """喜好愿望"""
+    __tablename__ = "wish_list"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    member_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, comment="所属成员")
+    content: Mapped[str] = mapped_column(String(200), nullable=False, comment="愿望内容")
+    category: Mapped[str] = mapped_column(String(50), default="", comment="分类")
+    source: Mapped[str] = mapped_column(
+        SAEnum("manual", "inferred", name="wish_source"),
+        default="manual",
+        comment="手动录入/系统推断",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )

--- a/家用备忘录智能体/backend/app/models/family.py
+++ b/家用备忘录智能体/backend/app/models/family.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+家庭空间与家庭成员模型。
+"""
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import String, Enum as SAEnum, DateTime, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class Family(Base):
+    __tablename__ = "family"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    name: Mapped[str] = mapped_column(String(50), default="我的家庭")
+    invite_code: Mapped[str] = mapped_column(String(10), nullable=True, index=True)
+    invite_code_expire: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+
+    members = relationship("FamilyMember", back_populates="family")
+
+
+class FamilyMember(Base):
+    __tablename__ = "family_member"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), nullable=True, index=True)
+    openid: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    role: Mapped[str] = mapped_column(
+        SAEnum("husband", "wife", name="member_role"), nullable=True
+    )
+    nickname: Mapped[str] = mapped_column(String(50), default="")
+    avatar: Mapped[str] = mapped_column(String(256), default="")
+    notify_channels: Mapped[str] = mapped_column(
+        String(100), default='["wechat"]',
+        comment="通知渠道 JSON 数组，如 ['wechat','sms']",
+    )
+    quiet_hours: Mapped[str] = mapped_column(
+        String(50), nullable=True,
+        comment="免打扰时段 JSON，如 {\"start\":\"22:00\",\"end\":\"08:00\"}",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+
+    family = relationship("Family", back_populates="members")

--- a/家用备忘录智能体/backend/app/models/finance.py
+++ b/家用备忘录智能体/backend/app/models/finance.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+F3 家庭收支记录模型。
+"""
+import uuid
+from datetime import datetime, date, timezone
+from decimal import Decimal
+from sqlalchemy import String, Text, Enum as SAEnum, DateTime, Date, Numeric
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class IncomeExpense(Base):
+    """收支记录"""
+    __tablename__ = "income_expense"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    type: Mapped[str] = mapped_column(
+        SAEnum("expense", "income", name="ie_type"),
+        nullable=False,
+        comment="支出/收入",
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    category: Mapped[str] = mapped_column(String(50), default="", comment="分类")
+    note: Mapped[str] = mapped_column(Text, default="", comment="备注")
+    payer_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="谁付的")
+    record_date: Mapped[date] = mapped_column(Date, nullable=False, comment="日期")
+    source_type: Mapped[str] = mapped_column(
+        String(50), default="manual",
+        comment="来源类型: manual/shopping/payment/vehicle",
+    )
+    source_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="来源关联ID")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )

--- a/家用备忘录智能体/backend/app/models/memo.py
+++ b/家用备忘录智能体/backend/app/models/memo.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+通用备忘条目模型。
+
+所有待办/提醒的通用抽象，各模块（F1/F4/F7）的提醒统一走 memo_item 调度。
+"""
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import String, Text, Enum as SAEnum, DateTime, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class MemoItem(Base):
+    __tablename__ = "memo_item"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False, comment="备忘内容(自然语言原文)")
+    category: Mapped[str] = mapped_column(
+        SAEnum(
+            "financial", "shopping", "vehicle", "health", "anniversary",
+            "social", "document", "other",
+            name="memo_category",
+        ),
+        default="other",
+        comment="分类",
+    )
+    due_time: Mapped[datetime] = mapped_column(DateTime, nullable=True, comment="到期时间")
+    repeat_rule: Mapped[dict] = mapped_column(JSON, nullable=True, comment="重复规则")
+    assignee_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="负责人member_id")
+    creator_id: Mapped[str] = mapped_column(String(36), nullable=False, comment="创建人member_id")
+    status: Mapped[str] = mapped_column(
+        SAEnum("pending", "done", "cancelled", name="memo_status"),
+        default="pending",
+    )
+    source_type: Mapped[str] = mapped_column(
+        SAEnum("chat", "manual", name="memo_source"),
+        default="chat",
+    )
+    biz_type: Mapped[str] = mapped_column(String(50), nullable=True, comment="业务类型: payment/vehicle/anniversary等")
+    biz_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="业务记录ID")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/家用备忘录智能体/backend/app/models/payment.py
+++ b/家用备忘录智能体/backend/app/models/payment.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+F1 周期性缴费模型。
+"""
+import uuid
+from datetime import datetime, date, timezone
+from decimal import Decimal
+from sqlalchemy import String, Integer, Enum as SAEnum, DateTime, Date, Numeric, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class PaymentItem(Base):
+    """缴费项目配置"""
+    __tablename__ = "payment_item"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    name: Mapped[str] = mapped_column(
+        SAEnum("water", "electric", "gas", "property", name="payment_name"),
+        nullable=False,
+        comment="水费/电费/燃气费/物业费",
+    )
+    frequency: Mapped[str] = mapped_column(
+        SAEnum("monthly", "half_yearly", name="payment_frequency"),
+        nullable=False,
+    )
+    reminder_day: Mapped[int] = mapped_column(Integer, default=15, comment="每月提醒日")
+    advance_days: Mapped[int] = mapped_column(Integer, default=3, comment="提前几天提醒")
+    estimated_amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class PaymentRecord(Base):
+    """缴费记录"""
+    __tablename__ = "payment_record"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    payment_item_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    actual_amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True)
+    paid_date: Mapped[date] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(
+        SAEnum("unpaid", "paid", "overdue", name="payment_status"),
+        default="unpaid",
+    )
+    income_expense_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="关联F3收支记录")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )

--- a/家用备忘录智能体/backend/app/models/shopping.py
+++ b/家用备忘录智能体/backend/app/models/shopping.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+F2 购物清单模型。
+"""
+import uuid
+from datetime import datetime, date, timezone
+from decimal import Decimal
+from sqlalchemy import String, Text, Enum as SAEnum, DateTime, Date, Numeric, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class ShoppingItem(Base):
+    """购物清单物品"""
+    __tablename__ = "shopping_item"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    list_type: Mapped[str] = mapped_column(
+        SAEnum("household", "husband", "wife", name="shopping_list_type"),
+        nullable=False,
+        comment="家用/老公个人/老婆个人",
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False, comment="物品名称")
+    category: Mapped[str] = mapped_column(String(50), default="", comment="分类")
+    image: Mapped[str] = mapped_column(String(256), default="", comment="图片URL")
+    estimated_price: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True, comment="预估价格")
+    purchase_reason: Mapped[str] = mapped_column(Text, default="", comment="购买理由")
+    status: Mapped[str] = mapped_column(
+        SAEnum("pending", "bought", "cancelled", name="shopping_status"),
+        default="pending",
+    )
+    actual_price: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True, comment="实际价格")
+    purchase_method: Mapped[str] = mapped_column(String(50), default="", comment="购买方式")
+    purchase_date: Mapped[date] = mapped_column(Date, nullable=True, comment="购买日期")
+    created_by: Mapped[str] = mapped_column(String(36), nullable=False, comment="创建人member_id")
+    assignee: Mapped[str] = mapped_column(String(36), nullable=True, comment="负责人member_id")
+    income_expense_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="关联F3收支记录")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class HouseholdAgreement(Base):
+    """家用清单同意表"""
+    __tablename__ = "household_agreement"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    shopping_item_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    member_id: Mapped[str] = mapped_column(String(36), nullable=False, comment="家庭成员")
+    agreement: Mapped[bool] = mapped_column(Boolean, nullable=False, comment="同意/不同意")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class ShoppingComment(Base):
+    """购物清单评论"""
+    __tablename__ = "shopping_comment"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    shopping_item_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    from_member_id: Mapped[str] = mapped_column(String(36), nullable=False, comment="评论人")
+    to_member_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="回复对象")
+    content: Mapped[str] = mapped_column(Text, nullable=False, comment="评论内容")
+    parent_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="父评论ID")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )

--- a/家用备忘录智能体/backend/app/models/vehicle.py
+++ b/家用备忘录智能体/backend/app/models/vehicle.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+F4 车辆管理模型。
+"""
+import uuid
+from datetime import datetime, date, timezone
+from decimal import Decimal
+from sqlalchemy import String, Text, Integer, Enum as SAEnum, DateTime, Date, Numeric
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+
+def gen_uuid():
+    return str(uuid.uuid4())
+
+
+class VehicleInfo(Base):
+    """车辆信息"""
+    __tablename__ = "vehicle_info"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    family_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    brand: Mapped[str] = mapped_column(String(50), default="", comment="品牌")
+    model: Mapped[str] = mapped_column(String(50), default="", comment="型号")
+    plate_number: Mapped[str] = mapped_column(String(20), default="", comment="车牌号")
+    purchase_date: Mapped[date] = mapped_column(Date, nullable=True, comment="购买日期")
+    insurance_expire: Mapped[date] = mapped_column(Date, nullable=True, comment="保险到期日")
+    insurance_company: Mapped[str] = mapped_column(String(100), default="", comment="保险公司")
+    maintenance_shop: Mapped[str] = mapped_column(String(100), default="", comment="4S店名称")
+    maintenance_address: Mapped[str] = mapped_column(String(200), default="", comment="4S店地址")
+    maintenance_contact: Mapped[str] = mapped_column(String(50), default="", comment="联系人")
+    maintenance_phone: Mapped[str] = mapped_column(String(20), default="", comment="联系电话")
+    next_maintenance_date: Mapped[date] = mapped_column(Date, nullable=True, comment="下次保养日期")
+    next_maintenance_mileage: Mapped[int] = mapped_column(Integer, nullable=True, comment="下次保养里程")
+    next_inspection_date: Mapped[date] = mapped_column(Date, nullable=True, comment="下次年检日期")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class VehicleExpense(Base):
+    """用车支出"""
+    __tablename__ = "vehicle_expense"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    vehicle_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
+    expense_type: Mapped[str] = mapped_column(
+        SAEnum(
+            "fuel", "charging", "insurance", "violation", "maintenance", "other",
+            name="vehicle_expense_type",
+        ),
+        nullable=False,
+        comment="加油/充电/保险/违章/保养/其他",
+    )
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    location: Mapped[str] = mapped_column(String(100), default="", comment="地点")
+    date: Mapped[date] = mapped_column(Date, nullable=False, comment="日期")
+    note: Mapped[str] = mapped_column(Text, default="", comment="备注")
+    income_expense_id: Mapped[str] = mapped_column(String(36), nullable=True, comment="关联F3")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class DrivingLicense(Base):
+    """驾驶分记录"""
+    __tablename__ = "driving_license"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
+    member_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, comment="家庭成员")
+    violation_date: Mapped[date] = mapped_column(Date, nullable=False, comment="违章日期")
+    location: Mapped[str] = mapped_column(String(100), default="", comment="违章地点")
+    reason: Mapped[str] = mapped_column(String(200), default="", comment="违章原因")
+    deduction: Mapped[int] = mapped_column(Integer, default=0, comment="扣分")
+    fine: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=True, comment="罚款金额")
+    remaining_points: Mapped[int] = mapped_column(Integer, default=12, comment="剩余分数")
+    clear_date: Mapped[date] = mapped_column(Date, nullable=True, comment="清零日期")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )

--- a/家用备忘录智能体/backend/app/schemas/anniversary.py
+++ b/家用备忘录智能体/backend/app/schemas/anniversary.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import date
+from decimal import Decimal
+
+
+class AnniversaryCreate(BaseModel):
+    name: str
+    date: date
+    reminder_days: int = 7
+
+
+class AnniversaryUpdate(BaseModel):
+    name: Optional[str] = None
+    date: Optional[date] = None
+    reminder_days: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+class AnniversaryOut(BaseModel):
+    id: str
+    name: str
+    date: date
+    reminder_days: int
+    is_active: bool
+    plans: List[dict] = []
+
+    class Config:
+        from_attributes = True
+
+
+class AnniversaryPlanCreate(BaseModel):
+    plan_type: str  # gift / restaurant / cake / activity / other
+    content: str
+    amount: Optional[Decimal] = None
+
+
+class AnniversaryPlanOut(BaseModel):
+    id: str
+    plan_type: str
+    content: str
+    status: str
+    amount: Optional[Decimal] = None
+
+    class Config:
+        from_attributes = True
+
+
+class WishItemCreate(BaseModel):
+    content: str
+    category: str = ""
+
+
+class WishItemOut(BaseModel):
+    id: str
+    content: str
+    category: str
+    source: str
+    created_at: str
+
+    class Config:
+        from_attributes = True

--- a/家用备忘录智能体/backend/app/schemas/auth.py
+++ b/家用备忘录智能体/backend/app/schemas/auth.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional
+
+
+class LoginRequest(BaseModel):
+    code: str  # 微信 wx.login 返回的 code
+
+
+class LoginResponse(BaseModel):
+    token: str
+    member_id: str
+    has_family: bool
+    role: Optional[str] = None
+
+
+class MemberInfo(BaseModel):
+    id: str
+    openid: str
+    role: Optional[str] = None
+    nickname: str
+    avatar: str
+    created_at: str
+
+    class Config:
+        from_attributes = True

--- a/家用备忘录智能体/backend/app/schemas/chat.py
+++ b/家用备忘录智能体/backend/app/schemas/chat.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional, Any
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    intent: str
+    reply: str
+    data: Optional[Any] = None
+    need_confirm: bool = False
+
+
+class ChatHistory(BaseModel):
+    id: str
+    message: str
+    reply: str
+    created_at: str

--- a/家用备忘录智能体/backend/app/schemas/family.py
+++ b/家用备忘录智能体/backend/app/schemas/family.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional, List
+
+
+class FamilyCreateRequest(BaseModel):
+    name: str = "我的家庭"
+    role: str = "husband"  # 创建者角色
+
+
+class FamilyJoinRequest(BaseModel):
+    invite_code: str
+    role: str = "wife"  # 加入者角色
+
+
+class FamilyInfo(BaseModel):
+    id: str
+    name: str
+    invite_code: Optional[str] = None
+    members: List[dict] = []
+
+    class Config:
+        from_attributes = True
+
+
+class RefreshCodeResponse(BaseModel):
+    invite_code: str
+    expire_at: str

--- a/家用备忘录智能体/backend/app/schemas/finance.py
+++ b/家用备忘录智能体/backend/app/schemas/finance.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import date
+from decimal import Decimal
+
+
+class FinanceRecordCreate(BaseModel):
+    type: str  # expense / income
+    amount: Decimal
+    category: str = ""
+    note: str = ""
+    payer_id: Optional[str] = None
+    record_date: date
+
+
+class FinanceRecordUpdate(BaseModel):
+    amount: Optional[Decimal] = None
+    category: Optional[str] = None
+    note: Optional[str] = None
+    payer_id: Optional[str] = None
+
+
+class FinanceRecordOut(BaseModel):
+    id: str
+    type: str
+    amount: Decimal
+    category: str
+    note: str
+    payer_id: Optional[str] = None
+    record_date: date
+    source_type: str
+
+    class Config:
+        from_attributes = True
+
+
+class MonthlyStats(BaseModel):
+    month: str
+    total_expense: float
+    total_income: float
+    by_category: dict

--- a/家用备忘录智能体/backend/app/schemas/payment.py
+++ b/家用备忘录智能体/backend/app/schemas/payment.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional
+from datetime import date
+from decimal import Decimal
+
+
+class PaymentItemOut(BaseModel):
+    id: str
+    name: str
+    frequency: str
+    reminder_day: int
+    advance_days: int
+    estimated_amount: Optional[Decimal] = None
+    is_active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class PaymentItemUpdate(BaseModel):
+    reminder_day: Optional[int] = None
+    advance_days: Optional[int] = None
+    estimated_amount: Optional[Decimal] = None
+    is_active: Optional[bool] = None
+
+
+class PaymentRecordOut(BaseModel):
+    id: str
+    payment_item_id: str
+    actual_amount: Optional[Decimal] = None
+    paid_date: Optional[date] = None
+    status: str
+
+    class Config:
+        from_attributes = True
+
+
+class PaymentRecordCreate(BaseModel):
+    payment_item_id: str
+    actual_amount: Decimal
+    paid_date: date

--- a/家用备忘录智能体/backend/app/schemas/shopping.py
+++ b/家用备忘录智能体/backend/app/schemas/shopping.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import date
+from decimal import Decimal
+
+
+class ShoppingItemCreate(BaseModel):
+    list_type: str  # household / husband / wife
+    name: str
+    category: str = ""
+    estimated_price: Optional[Decimal] = None
+    purchase_reason: str = ""
+    image: str = ""
+
+
+class ShoppingItemUpdate(BaseModel):
+    name: Optional[str] = None
+    category: Optional[str] = None
+    estimated_price: Optional[Decimal] = None
+    purchase_reason: Optional[str] = None
+    image: Optional[str] = None
+
+
+class ShoppingItemOut(BaseModel):
+    id: str
+    list_type: str
+    name: str
+    category: str
+    image: str
+    estimated_price: Optional[Decimal] = None
+    purchase_reason: str
+    status: str
+    actual_price: Optional[Decimal] = None
+    purchase_method: str
+    purchase_date: Optional[date] = None
+    created_by: str
+    assignee: Optional[str] = None
+    agreements: List[dict] = []
+    comments: List[dict] = []
+
+    class Config:
+        from_attributes = True
+
+
+class AgreementRequest(BaseModel):
+    agreement: bool
+
+
+class PurchaseRequest(BaseModel):
+    actual_price: Decimal
+    purchase_method: str = ""
+    purchase_date: date
+
+
+class CommentCreate(BaseModel):
+    content: str
+    to_member_id: Optional[str] = None
+    parent_id: Optional[str] = None

--- a/家用备忘录智能体/backend/app/schemas/vehicle.py
+++ b/家用备忘录智能体/backend/app/schemas/vehicle.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from pydantic import BaseModel
+from typing import Optional
+from datetime import date
+from decimal import Decimal
+
+
+class VehicleInfoUpdate(BaseModel):
+    brand: Optional[str] = None
+    model: Optional[str] = None
+    plate_number: Optional[str] = None
+    purchase_date: Optional[date] = None
+    insurance_expire: Optional[date] = None
+    insurance_company: Optional[str] = None
+    maintenance_shop: Optional[str] = None
+    maintenance_address: Optional[str] = None
+    maintenance_contact: Optional[str] = None
+    maintenance_phone: Optional[str] = None
+    next_maintenance_date: Optional[date] = None
+    next_maintenance_mileage: Optional[int] = None
+    next_inspection_date: Optional[date] = None
+
+
+class VehicleInfoOut(BaseModel):
+    id: str
+    brand: str
+    model: str
+    plate_number: str
+    purchase_date: Optional[date] = None
+    insurance_expire: Optional[date] = None
+    insurance_company: str
+    maintenance_shop: str
+    maintenance_address: str
+    maintenance_contact: str
+    maintenance_phone: str
+    next_maintenance_date: Optional[date] = None
+    next_maintenance_mileage: Optional[int] = None
+    next_inspection_date: Optional[date] = None
+
+    class Config:
+        from_attributes = True
+
+
+class VehicleExpenseCreate(BaseModel):
+    expense_type: str
+    amount: Decimal
+    location: str = ""
+    date: date
+    note: str = ""
+
+
+class VehicleExpenseOut(BaseModel):
+    id: str
+    expense_type: str
+    amount: Decimal
+    location: str
+    date: date
+    note: str
+
+    class Config:
+        from_attributes = True
+
+
+class DrivingLicenseCreate(BaseModel):
+    violation_date: date
+    location: str = ""
+    reason: str = ""
+    deduction: int = 0
+    fine: Optional[Decimal] = None
+
+
+class DrivingLicenseOut(BaseModel):
+    id: str
+    violation_date: date
+    location: str
+    reason: str
+    deduction: int
+    fine: Optional[Decimal] = None
+    remaining_points: int
+
+    class Config:
+        from_attributes = True

--- a/家用备忘录智能体/backend/app/services/nlu.py
+++ b/家用备忘录智能体/backend/app/services/nlu.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+"""
+NLU 自然语言理解服务。
+
+使用 LLM 进行意图识别和槽位抽取，输出结构化 JSON。
+"""
+import json
+from typing import Optional
+from openai import AsyncOpenAI
+from loguru import logger
+
+from app.config import settings
+
+# LLM 客户端
+_client: Optional[AsyncOpenAI] = None
+
+
+def get_llm_client() -> AsyncOpenAI:
+    """获取 LLM 客户端（懒加载）"""
+    global _client
+    if _client is None:
+        _client = AsyncOpenAI(
+            api_key=settings.LLM_API_KEY,
+            base_url=settings.LLM_BASE_URL,
+        )
+    return _client
+
+
+# 系统提示词：定义意图和槽位
+SYSTEM_PROMPT = """你是一个家庭备忘录智能体的自然语言理解引擎。你的任务是将用户的自然语言输入解析为结构化的意图和槽位。
+
+## 支持的意图 (intent)
+
+| 意图 | 说明 | 示例 |
+|------|------|------|
+| create_memo | 创建备忘/提醒 | "下周三交电费"、"明天下午三点接孩子" |
+| query_memo | 查询待办 | "我这个月有哪些待办"、"周末有什么安排" |
+| update_memo | 修改备忘 | "把那条改到晚上八点" |
+| delete_memo | 删除备忘 | "删掉刚才那条" |
+| mark_done | 标记完成 | "电费已经交了" |
+| create_shopping | 添加购物清单 | "买一箱牛奶"、"加个拖把到购物清单" |
+| agree_shopping | 同意/不同意购买 | "牛奶可以买"、"那个太贵了先不买" |
+| query_finance | 查收支 | "这月花了多少钱"、"上个月买菜花了多少" |
+| add_vehicle_expense | 记录用车支出 | "今天加油花了300" |
+| query_vehicle | 查车辆信息 | "车险什么时候到期" |
+| add_anniversary | 添加纪念日 | "记一下结婚纪念日是9月15号" |
+| query_anniversary | 查纪念日 | "我生日是什么时候" |
+| chat | 闲聊/问候 | "谢谢"、"早上好" |
+
+## 输出 JSON 格式
+
+```json
+{
+    "intent": "意图名称",
+    "slots": {
+        "content": "备忘内容（不含时间信息）",
+        "raw_time": "用户原文中的时间表达",
+        "resolved_time": "解析后的ISO时间(如无法确定则填空字符串)",
+        "time_confidence": 0.0-1.0,
+        "assignee": "负责人: self/partner/空",
+        "repeat": "重复规则: 如 {\"type\":\"monthly\",\"day\":15} 或 null",
+        "category": "分类: financial/shopping/vehicle/health/anniversary/other"
+    },
+    "need_confirm": false,
+    "reply": "给用户的自然语言回复（中文，简短友好）"
+}
+```
+
+## 规则
+1. 如果时间表达不明确（如"改天"、"有空的时候"），设置 need_confirm=true
+2. 如果用户没有指定负责人，默认 assignee="self"
+3. 仅当用户明确提到"提醒老公/老婆"时，才设置 assignee 为 partner
+4. 回复要简短（不超过50字），口语化，像家人之间的对话
+5. 对于闲聊（打招呼、感谢等），intent 设为 chat，不需要解析槽位"""
+
+
+async def parse_message(message: str, context: Optional[dict] = None) -> dict:
+    """
+    解析用户消息，返回结构化意图。
+
+    Args:
+        message: 用户输入的自然语言消息
+        context: 对话上下文（可选），包含最近操作等信息
+
+    Returns:
+        结构化意图结果字典
+    """
+    # 如果 LLM 未配置，使用关键词 fallback
+    if not settings.LLM_API_KEY:
+        logger.warning("LLM 未配置，使用关键词 fallback")
+        return _keyword_fallback(message)
+
+    try:
+        client = get_llm_client()
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+        ]
+
+        # 如果有上下文，加入
+        if context:
+            context_str = json.dumps(context, ensure_ascii=False)
+            messages.append({
+                "role": "system",
+                "content": f"对话上下文（最近一条操作）：{context_str}"
+            })
+
+        messages.append({"role": "user", "content": message})
+
+        response = await client.chat.completions.create(
+            model=settings.LLM_MODEL_NAME,
+            messages=messages,
+            temperature=0.1,
+            max_tokens=500,
+            response_format={"type": "json_object"},
+        )
+
+        result_text = response.choices[0].message.content
+        result = json.loads(result_text)
+
+        # 验证必要字段
+        if "intent" not in result:
+            result["intent"] = "chat"
+        if "slots" not in result:
+            result["slots"] = {}
+        if "reply" not in result:
+            result["reply"] = "好的，已收到。"
+        if "need_confirm" not in result:
+            result["need_confirm"] = False
+
+        logger.info(f"NLU 解析结果: {result.get('intent')} | 置信度: {result.get('slots', {}).get('time_confidence', 'N/A')}")
+        return result
+
+    except Exception as e:
+        logger.error(f"LLM 调用失败: {e}")
+        return _keyword_fallback(message)
+
+
+def _keyword_fallback(message: str) -> dict:
+    """
+    关键词匹配 fallback。
+    当 LLM 不可用时使用，仅覆盖基础场景。
+    """
+    msg = message.lower()
+
+    # 创建备忘
+    if any(kw in msg for kw in ["提醒", "记得", "交"]):
+        return {
+            "intent": "create_memo",
+            "slots": {
+                "content": message,
+                "raw_time": "",
+                "resolved_time": "",
+                "time_confidence": 0.0,
+                "assignee": "self",
+                "repeat": None,
+                "category": "other",
+            },
+            "need_confirm": True,
+            "reply": "好的，已记下了。请确认具体时间和内容。",
+        }
+
+    # 购物
+    if any(kw in msg for kw in ["买", "购物"]):
+        return {
+            "intent": "create_shopping",
+            "slots": {"content": message, "category": "shopping"},
+            "need_confirm": True,
+            "reply": "好的，已添加到购物清单。",
+        }
+
+    # 查询
+    if any(kw in msg for kw in ["查", "看", "有哪", "什么"]):
+        return {
+            "intent": "query_memo",
+            "slots": {},
+            "need_confirm": False,
+            "reply": "好的，帮你查一下。",
+        }
+
+    # 修改
+    if any(kw in msg for kw in ["改到", "改成", "修改", "换个"]):
+        return {
+            "intent": "update_memo",
+            "slots": {"content": message},
+            "need_confirm": True,
+            "reply": "好的，已帮你修改。",
+        }
+
+    # 删除
+    if any(kw in msg for kw in ["删", "取消", "不要"]):
+        return {
+            "intent": "delete_memo",
+            "slots": {},
+            "need_confirm": True,
+            "reply": "好的，已删除。",
+        }
+
+    # 完成
+    if any(kw in msg for kw in ["交了", "做了", "完了", "好了"]):
+        return {
+            "intent": "mark_done",
+            "slots": {},
+            "need_confirm": True,
+            "reply": "好的，已标记完成。",
+        }
+
+    # 车辆
+    if any(kw in msg for kw in ["加油", "充电", "车险", "违章"]):
+        return {
+            "intent": "add_vehicle_expense",
+            "slots": {"content": message, "category": "vehicle"},
+            "need_confirm": True,
+            "reply": "好的，已记录用车支出。",
+        }
+
+    # 纪念日
+    if any(kw in msg for kw in ["纪念日", "生日"]):
+        return {
+            "intent": "add_anniversary",
+            "slots": {"content": message, "category": "anniversary"},
+            "need_confirm": True,
+            "reply": "好的，已记录纪念日。",
+        }
+
+    # 默认：闲聊
+    return {
+        "intent": "chat",
+        "slots": {},
+        "need_confirm": False,
+        "reply": "收到！有什么需要帮忙的吗？",
+    }

--- a/家用备忘录智能体/backend/app/services/push.py
+++ b/家用备忘录智能体/backend/app/services/push.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+微信推送服务。
+
+使用微信小程序订阅消息进行推送。
+"""
+from typing import Optional
+from loguru import logger
+import httpx
+import json
+
+from app.config import settings
+
+
+class PushService:
+    """
+    推送服务。
+
+    目前支持微信订阅消息，后续可扩展 App Push、短信等通道。
+    """
+
+    def __init__(self):
+        self._access_token: Optional[str] = None
+        self._token_expire: float = 0
+
+    async def _get_access_token(self) -> Optional[str]:
+        """获取微信 access_token"""
+        now = __import__("time").time()
+        if self._access_token and now < self._token_expire:
+            return self._access_token
+
+        if not settings.WECHAT_APPID or not settings.WECHAT_SECRET:
+            logger.warning("微信小程序未配置，无法推送")
+            return None
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    "https://api.weixin.qq.com/cgi-bin/token",
+                    params={
+                        "grant_type": "client_credential",
+                        "appid": settings.WECHAT_APPID,
+                        "secret": settings.WECHAT_SECRET,
+                    },
+                )
+                data = resp.json()
+                if "access_token" in data:
+                    self._access_token = data["access_token"]
+                    self._token_expire = now + data.get("expires_in", 7200) - 300
+                    return self._access_token
+                else:
+                    logger.error(f"获取 access_token 失败: {data}")
+                    return None
+        except Exception as e:
+            logger.error(f"获取 access_token 异常: {e}")
+            return None
+
+    async def send_reminder(self, task: dict) -> bool:
+        """
+        发送提醒推送。
+
+        使用微信小程序订阅消息。
+        """
+        # TODO: 接入微信订阅消息 API
+        # 需要用户先订阅，获取 template_id 和用户 openid
+
+        memo_id = task.get("memo_id", "")
+        family_id = task.get("family_id", "")
+        due_time = task.get("due_time", "")
+        overdue_count = task.get("overdue_count", 0)
+
+        logger.info(f"推送提醒: memo_id={memo_id}, due_time={due_time}, overdue_count={overdue_count}")
+
+        # 逾期升级策略
+        if overdue_count >= 7:
+            # 逾期7天，通知配偶
+            logger.info(f"逾期7天，需通知配偶: {memo_id}")
+        elif overdue_count >= 3:
+            # 逾期3天，升级推送频次
+            logger.info(f"逾期3天，升级推送: {memo_id}")
+
+        # TODO: 实际调用微信订阅消息接口
+        # template_msg = {
+        #     "touser": "openid",
+        #     "template_id": "template_id",
+        #     "page": "pages/index/index",
+        #     "data": {
+        #         "thing1": {"value": "缴费提醒"},
+        #         "time2": {"value": due_time},
+        #         "thing3": {"value": "请及时处理"},
+        #     },
+        # }
+
+        return True
+
+    async def send_subscribe_guide(self, openid: str) -> bool:
+        """
+        引导用户订阅提醒消息。
+        在创建提醒时调用。
+        """
+        # TODO: 调用微信订阅消息引导
+        return True
+
+
+# 单例
+push_service = PushService()

--- a/家用备忘录智能体/backend/app/services/reminder.py
+++ b/家用备忘录智能体/backend/app/services/reminder.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""
+提醒调度服务。
+
+基于 Redis 的延迟队列实现，后台 worker 轮询到期任务并推送通知。
+"""
+import json
+import asyncio
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+from loguru import logger
+import redis.asyncio as aioredis
+
+from app.config import settings
+
+
+class ReminderService:
+    """
+    提醒调度服务。
+
+    使用 Redis zset 管理定时任务：
+    - key: reminder:{family_id}
+    - score: 下次提醒时间戳（秒）
+    - value: JSON 格式的任务信息
+    """
+
+    def __init__(self):
+        self._redis: Optional[aioredis.Redis] = None
+        self._running = False
+        self._worker_task: Optional[asyncio.Task] = None
+
+    async def get_redis(self) -> aioredis.Redis:
+        """获取 Redis 客户端（懒加载）"""
+        if self._redis is None:
+            self._redis = aioredis.from_url(
+                settings.REDIS_URL,
+                decode_responses=True,
+            )
+        return self._redis
+
+    async def schedule(self, memo_id: str, family_id: str, due_time: datetime,
+                       repeat_rule: Optional[dict] = None) -> bool:
+        """
+        安排一个提醒任务。
+
+        Args:
+            memo_id: 备忘条目 ID
+            family_id: 家庭空间 ID
+            due_time: 到期时间
+            repeat_rule: 重复规则，如 {"type": "monthly", "day": 15}
+
+        Returns:
+            是否成功
+        """
+        try:
+            redis = await self.get_redis()
+            key = f"reminder:{family_id}"
+
+            task = {
+                "memo_id": memo_id,
+                "family_id": family_id,
+                "due_time": due_time.isoformat(),
+                "repeat_rule": repeat_rule,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "overdue_count": 0,
+            }
+
+            score = due_time.timestamp()
+            await redis.zadd(key, {json.dumps(task, ensure_ascii=False): score})
+            logger.info(f"提醒已安排: {memo_id} -> {due_time.isoformat()}")
+            return True
+        except Exception as e:
+            logger.error(f"安排提醒失败: {e}")
+            return False
+
+    async def cancel(self, memo_id: str, family_id: str) -> bool:
+        """取消提醒"""
+        try:
+            redis = await self.get_redis()
+            key = f"reminder:{family_id}"
+
+            # 查找并删除匹配的任务
+            tasks = await redis.zrange(key, 0, -1)
+            for task_json in tasks:
+                task = json.loads(task_json)
+                if task.get("memo_id") == memo_id:
+                    await redis.zrem(key, task_json)
+                    logger.info(f"提醒已取消: {memo_id}")
+                    return True
+            return False
+        except Exception as e:
+            logger.error(f"取消提醒失败: {e}")
+            return False
+
+    async def mark_overdue(self, memo_id: str, family_id: str) -> Optional[int]:
+        """标记逾期，返回逾期次数"""
+        try:
+            redis = await self.get_redis()
+            key = f"reminder:{family_id}"
+
+            tasks = await redis.zrange(key, 0, -1)
+            for task_json in tasks:
+                task = json.loads(task_json)
+                if task.get("memo_id") == memo_id:
+                    task["overdue_count"] = task.get("overdue_count", 0) + 1
+                    # 重新入队，下次提醒时间 = 当前时间 + 24小时
+                    new_due = datetime.now(timezone.utc) + timedelta(hours=24)
+                    task["due_time"] = new_due.isoformat()
+                    await redis.zrem(key, task_json)
+                    await redis.zadd(key, {json.dumps(task, ensure_ascii=False): new_due.timestamp()})
+                    return task["overdue_count"]
+            return None
+        except Exception as e:
+            logger.error(f"标记逾期失败: {e}")
+            return None
+
+    async def get_due_tasks(self, family_id: str, batch_size: int = 50) -> list[dict]:
+        """获取到期的任务"""
+        try:
+            redis = await self.get_redis()
+            key = f"reminder:{family_id}"
+            now = datetime.now(timezone.utc).timestamp()
+
+            tasks = await redis.zrangebyscore(key, 0, now, start=0, num=batch_size)
+            result = []
+            for task_json in tasks:
+                try:
+                    task = json.loads(task_json)
+                    result.append(task)
+                except json.JSONDecodeError:
+                    continue
+
+            # 移除已到期的任务
+            if result:
+                await redis.zremrangebyscore(key, 0, now)
+
+            return result
+        except Exception as e:
+            logger.error(f"获取到期任务失败: {e}")
+            return []
+
+    async def get_upcoming(self, family_id: str, limit: int = 20) -> list[dict]:
+        """获取即将到来的提醒"""
+        try:
+            redis = await self.get_redis()
+            key = f"reminder:{family_id}"
+            now = datetime.now(timezone.utc).timestamp()
+
+            tasks = await redis.zrangebyscore(key, now, "+inf", start=0, num=limit)
+            result = []
+            for task_json in tasks:
+                try:
+                    task = json.loads(task_json)
+                    due = datetime.fromisoformat(task["due_time"])
+                    task["due_time_display"] = due.strftime("%m月%d日 %H:%M")
+                    task["remaining_seconds"] = int(due.timestamp() - now)
+                    result.append(task)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+            return result
+        except Exception as e:
+            logger.error(f"获取即将到来的提醒失败: {e}")
+            return []
+
+    async def start_worker(self):
+        """启动后台 worker，持续轮询到期任务"""
+        if self._running:
+            return
+
+        self._running = True
+        self._worker_task = asyncio.create_task(self._worker_loop())
+        logger.info("提醒调度 worker 已启动")
+
+    async def stop_worker(self):
+        """停止后台 worker"""
+        self._running = False
+        if self._worker_task:
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+        logger.info("提醒调度 worker 已停止")
+
+    async def _worker_loop(self):
+        """Worker 主循环"""
+        while self._running:
+            try:
+                # 轮询所有家庭空间的到期任务
+                # TODO: 优化为按家庭空间遍历
+                redis = await self.get_redis()
+
+                # 获取所有 reminder key
+                cursor = 0
+                while True:
+                    cursor, keys = await redis.scan(cursor, match="reminder:*", count=100)
+                    for key in keys:
+                        tasks = await self._process_family_tasks(key)
+                        for task in tasks:
+                            await self._push_notification(task)
+
+                    if cursor == 0:
+                        break
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Worker 轮询异常: {e}")
+
+            # 轮询间隔
+            await asyncio.sleep(settings.REMINDER_POLL_INTERVAL)
+
+    async def _process_family_tasks(self, key: str) -> list[dict]:
+        """处理单个家庭空间的到期任务"""
+        try:
+            redis = await self.get_redis()
+            now = datetime.now(timezone.utc).timestamp()
+
+            tasks = await redis.zrangebyscore(key, 0, now)
+            if not tasks:
+                return []
+
+            # 移除到期任务
+            await redis.zremrangebyscore(key, 0, now)
+
+            result = []
+            for task_json in tasks:
+                try:
+                    task = json.loads(task_json)
+                    # 如果有重复规则，重新安排
+                    if task.get("repeat_rule"):
+                        new_due = self._calc_next_repeat(task)
+                        if new_due:
+                            task["due_time"] = new_due.isoformat()
+                            task["overdue_count"] = 0
+                            await redis.zadd(key, {json.dumps(task, ensure_ascii=False): new_due.timestamp()})
+                    result.append(task)
+                except json.JSONDecodeError:
+                    continue
+
+            return result
+        except Exception as e:
+            logger.error(f"处理家庭任务失败 {key}: {e}")
+            return []
+
+    def _calc_next_repeat(self, task: dict) -> Optional[datetime]:
+        """计算下次重复时间"""
+        from dateutil.relativedelta import relativedelta
+
+        rule = task.get("repeat_rule")
+        if not rule:
+            return None
+
+        due = datetime.fromisoformat(task["due_time"])
+        now = datetime.now(timezone.utc)
+
+        repeat_type = rule.get("type")
+        if repeat_type == "daily":
+            next_due = due + timedelta(days=1)
+            while next_due <= now:
+                next_due += timedelta(days=1)
+            return next_due
+
+        elif repeat_type == "weekly":
+            next_due = due + timedelta(weeks=1)
+            while next_due <= now:
+                next_due += timedelta(weeks=1)
+            return next_due
+
+        elif repeat_type == "monthly":
+            day = rule.get("day", due.day)
+            next_due = due + relativedelta(months=1)
+            try:
+                next_due = next_due.replace(day=min(day, 28))
+            except ValueError:
+                next_due = next_due.replace(day=28)
+            while next_due <= now:
+                next_due += relativedelta(months=1)
+                try:
+                    next_due = next_due.replace(day=min(day, 28))
+                except ValueError:
+                    next_due = next_due.replace(day=28)
+            return next_due
+
+        return None
+
+    async def _push_notification(self, task: dict):
+        """推送通知（调用 push 服务）"""
+        try:
+            from app.services.push import push_service
+            await push_service.send_reminder(task)
+        except Exception as e:
+            logger.error(f"推送通知失败: {e}")
+
+
+# 单例
+reminder_service = ReminderService()

--- a/家用备忘录智能体/backend/app/services/time_parser.py
+++ b/家用备忘录智能体/backend/app/services/time_parser.py
@@ -1,0 +1,350 @@
+# -*- coding: utf-8 -*-
+"""
+时间解析服务。
+
+规则引擎 + LLM 兜底，将中文时间表达式解析为具体时间。
+"""
+import re
+import json
+from datetime import datetime, timedelta, date, timezone
+from typing import Optional, Tuple
+from loguru import logger
+from dateutil.relativedelta import relativedelta
+
+from app.config import settings
+
+# 时区
+CST = timezone(timedelta(hours=8))
+
+
+class TimeParser:
+    """
+    时间解析器。
+    先用规则引擎匹配常见表达，匹配不到时调用 LLM 兜底。
+    """
+
+    def __init__(self):
+        self._today = date.today()
+        self._now = datetime.now(CST)
+
+    def resolve(self, expr: str, context: Optional[dict] = None) -> Tuple[Optional[str], float]:
+        """
+        解析时间表达式。
+
+        Args:
+            expr: 时间表达式，如 "明天下午三点"、"下周三"、"月底"
+            context: 上下文信息（如家庭习惯）
+
+        Returns:
+            (resolved_iso_time, confidence)
+            - 无法解析时返回 (None, 0.0)
+        """
+        if not expr or not expr.strip():
+            return None, 0.0
+
+        expr = expr.strip()
+
+        # 1. 规则引擎匹配
+        result = self._rule_match(expr)
+        if result[0]:
+            return result
+
+        # 2. LLM 兜底
+        if settings.LLM_API_KEY:
+            result = self._llm_fallback(expr, context)
+            if result[0]:
+                return result
+
+        # 3. 无法解析
+        return None, 0.0
+
+    def _rule_match(self, expr: str) -> Tuple[Optional[str], float]:
+        """规则引擎匹配常见时间表达"""
+        expr = expr.strip().lower()
+
+        # ===== 绝对时间 =====
+        # 匹配 "2026年9月2日 10:00" 或 "2026-09-02 10:00"
+        m = re.search(r'(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})[日]?\s*(\d{1,2})[:：](\d{2})', expr)
+        if m:
+            try:
+                dt = datetime(int(m.group(1)), int(m.group(2)), int(m.group(3)),
+                             int(m.group(4)), int(m.group(5)), tzinfo=CST)
+                return (dt.isoformat(), 1.0)
+            except ValueError:
+                pass
+
+        # 匹配 "9月2日 10:00"
+        m = re.search(r'(\d{1,2})[月](\d{1,2})[日]?\s*(\d{1,2})[:：](\d{2})', expr)
+        if m:
+            try:
+                dt = datetime(self._today.year, int(m.group(1)), int(m.group(2)),
+                             int(m.group(3)), int(m.group(4)), tzinfo=CST)
+                if dt.date() < self._today:
+                    dt = dt.replace(year=dt.year + 1)
+                return (dt.isoformat(), 1.0)
+            except ValueError:
+                pass
+
+        # 匹配 "9月2日" 无时间
+        m = re.search(r'(\d{1,2})[月](\d{1,2})[日]号?', expr)
+        if m:
+            try:
+                d = date(self._today.year, int(m.group(1)), int(m.group(2)))
+                if d < self._today:
+                    d = d.replace(year=d.year + 1)
+                dt = datetime.combine(d, datetime.min.time(), tzinfo=CST)
+                return (dt.isoformat(), 0.9)
+            except ValueError:
+                pass
+
+        # ===== 相对时间 =====
+
+        # 今天/明天/后天/大后天
+        day_map = {
+            "大后天": 3, "后天": 2, "明天": 1, "今天": 0, "今日": 0,
+            "明日": 1, "昨日": -1, "昨天": -1, "前天": -2,
+        }
+        for kw, offset in day_map.items():
+            if kw in expr:
+                target = self._today + timedelta(days=offset)
+                time_str = self._extract_time(expr)
+                dt = self._combine(target, time_str)
+                return (dt.isoformat(), 0.95)
+
+        # 下周几
+        weekday_map = {"一": 0, "二": 1, "三": 2, "四": 3, "五": 4, "六": 5, "日": 6, "天": 6}
+        m = re.search(r'下[周]([一二三四五六日天])', expr)
+        if m:
+            target_weekday = weekday_map.get(m.group(1), 0)
+            # 计算下周的星期几
+            days_ahead = target_weekday - self._today.weekday()
+            if days_ahead <= 0:
+                days_ahead += 7
+            days_ahead += 7  # 下周
+            target = self._today + timedelta(days=days_ahead)
+            time_str = self._extract_time(expr)
+            dt = self._combine(target, time_str)
+            return (dt.isoformat(), 0.9)
+
+        # 这周几
+        m = re.search(r'这[周]([一二三四五六日天])', expr)
+        if m:
+            target_weekday = weekday_map.get(m.group(1), 0)
+            days_ahead = target_weekday - self._today.weekday()
+            if days_ahead < 0:
+                days_ahead += 7
+            target = self._today + timedelta(days=days_ahead)
+            time_str = self._extract_time(expr)
+            dt = self._combine(target, time_str)
+            return (dt.isoformat(), 0.9)
+
+        # 下个月
+        if "下个月" in expr:
+            next_month = self._today + relativedelta(months=1)
+            day = self._extract_day(expr) or self._today.day
+            try:
+                target = next_month.replace(day=min(day, 28))  # 避免超出月份天数
+                time_str = self._extract_time(expr)
+                dt = self._combine(target, time_str)
+                return (dt.isoformat(), 0.85)
+            except ValueError:
+                pass
+
+        # 月底
+        if "月底" in expr:
+            import calendar
+            last_day = calendar.monthrange(self._today.year, self._today.month)[1]
+            target = self._today.replace(day=last_day)
+            time_str = self._extract_time(expr)
+            dt = self._combine(target, time_str)
+            return (dt.isoformat(), 0.85)
+
+        # 月初
+        if "月初" in expr:
+            target = self._today.replace(day=1)
+            time_str = self._extract_time(expr)
+            dt = self._combine(target, time_str)
+            return (dt.isoformat(), 0.85)
+
+        # 周末
+        if "周末" in expr:
+            days_to_saturday = (5 - self._today.weekday()) % 7
+            if days_to_saturday == 0:
+                days_to_saturday = 7  # 这周六已经过了，到下周六
+            target = self._today + timedelta(days=days_to_saturday)
+            time_str = self._extract_time(expr) or "10:00"
+            dt = self._combine(target, time_str)
+            return (dt.isoformat(), 0.8)
+
+        # 晚上/下午/早上/上午/中午
+        time_map = {
+            "早上": "08:00", "早晨": "07:00", "上午": "09:00",
+            "中午": "12:00", "下午": "14:00", "晚上": "19:00",
+            "今晚": "20:00", "明早": "08:00", "明晚": "20:00",
+        }
+        for kw, default_time in time_map.items():
+            if expr.startswith(kw) or expr == kw:
+                target = self._today
+                if kw in ("明早", "明晚"):
+                    target = self._today + timedelta(days=1)
+                # 如果已经过了这个时间，推到明天
+                time_str = self._extract_time(expr) or default_time
+                dt = self._combine(target, time_str)
+                # 如果已经过了，推到明天
+                if dt <= self._now:
+                    dt = dt + timedelta(days=1)
+                return (dt.isoformat(), 0.9)
+
+        return None, 0.0
+
+    def _extract_time(self, expr: str, is_evening: bool = False) -> Optional[str]:
+        """从表达式中提取时间部分，如 '下午三点' -> '15:00'"""
+        # 中文数字映射
+        cn_digits = {
+            "零": 0, "一": 1, "二": 2, "三": 3, "四": 4,
+            "五": 5, "六": 6, "七": 7, "八": 8, "九": 9,
+            "两": 2,
+        }
+
+        def _is_evening(expr: str) -> bool:
+            return any(kw in expr for kw in ["下午", "晚上", "今晚", "明晚", "半夜"])
+
+        # 优先处理 "X点半"（含中文数字）
+        if "半" in expr:
+            m = re.search(r'([零一二三四五六七八九两\d]{1,2})点半', expr)
+            if m:
+                hour_str = m.group(1)
+                hour = cn_digits.get(hour_str, int(hour_str) if hour_str.isdigit() else 0)
+                if _is_evening(expr) and hour < 12:
+                    hour += 12
+                return f"{hour:02d}:30"
+
+        # 尝试匹配 "X点" 或 "X点Y分"（支持中文数字）
+        m = re.search(r'([零一二三四五六七八九两\d]{1,2})[：:点](\d{0,2})', expr)
+        if m:
+            hour_str = m.group(1)
+            # 中文数字转阿拉伯数字
+            hour = cn_digits.get(hour_str, int(hour_str) if hour_str.isdigit() else 0)
+            minute = int(m.group(2)) if m.group(2) else 0
+            # 处理下午/晚上/今晚
+            if _is_evening(expr) and hour < 12:
+                hour += 12
+            elif "凌晨" in expr or "半夜" in expr:
+                if hour < 6:
+                    pass  # 凌晨时间
+            elif "中午" in expr:
+                if hour < 12:
+                    hour = 12  # 中午12点
+            else:
+                # 默认上午
+                if hour > 12 and "下午" not in expr and "晚上" not in expr:
+                    pass  # 已经是24小时制
+            return f"{hour:02d}:{minute:02d}"
+
+        # 半/半点
+        if "半" in expr:
+            m = re.search(r'([零一二三四五六七八九两\d]{1,2})点半', expr)
+            if m:
+                hour_str = m.group(1)
+                hour = cn_digits.get(hour_str, int(hour_str) if hour_str.isdigit() else 0)
+                minute = 30
+                if any(kw in expr for kw in ["下午", "晚上", "今晚", "明晚", "半夜"]):
+                    if hour < 12:
+                        hour += 12
+                return f"{hour:02d}:{minute:02d}"
+                if "下午" in expr or "晚上" in expr:
+                    if hour < 12:
+                        hour += 12
+                return f"{hour:02d}:30"
+
+        return None
+
+    def _extract_day(self, expr: str) -> Optional[int]:
+        """提取日期数字"""
+        cn_digits = {
+            "零": 0, "一": 1, "二": 2, "三": 3, "四": 4,
+            "五": 5, "六": 6, "七": 7, "八": 8, "九": 9,
+            "两": 2,
+        }
+        m = re.search(r'(\d{1,2})[日号]', expr)
+        if m:
+            return int(m.group(1))
+        # 中文数字日期
+        m = re.search(r'([一二三四五六七八九两十]{1,3})[日号]', expr)
+        if m:
+            day_str = m.group(1)
+            if "十" in day_str:
+                parts = day_str.split("十")
+                if parts[0] and parts[1]:
+                    return cn_digits.get(parts[0], 0) * 10 + cn_digits.get(parts[1], 0)
+                elif parts[0]:
+                    return cn_digits.get(parts[0], 0) * 10
+                else:
+                    return cn_digits.get(parts[1], 0) + 10
+            return cn_digits.get(day_str, 0)
+        return None
+
+    def _combine(self, target_date: date, time_str: Optional[str]) -> datetime:
+        """将日期和时间组合为 datetime"""
+        if time_str:
+            parts = time_str.split(":")
+            hour = int(parts[0])
+            minute = int(parts[1]) if len(parts) > 1 else 0
+            return datetime(target_date.year, target_date.month, target_date.day,
+                          hour, minute, tzinfo=CST)
+        return datetime(target_date.year, target_date.month, target_date.day,
+                      10, 0, tzinfo=CST)  # 默认上午10点
+
+    def _llm_fallback(self, expr: str, context: Optional[dict] = None) -> Tuple[Optional[str], float]:
+        """LLM 兜底解析复杂时间表达"""
+        try:
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(
+                api_key=settings.LLM_API_KEY,
+                base_url=settings.LLM_BASE_URL,
+            )
+
+            today = self._today.isoformat()
+            now = self._now.strftime("%Y-%m-%d %H:%M")
+
+            prompt = f"""你是一个时间解析专家。请将中文时间表达式解析为 ISO 格式时间。
+
+今天日期: {today}
+当前时间: {now}
+
+时间表达式: "{expr}"
+
+请输出 JSON:
+{{
+    "resolved_time": "ISO格式时间(如2026-09-02T10:00:00+08:00)",
+    "confidence": 0.0-1.0,
+    "reason": "解析理由"
+}}
+
+如果无法确定，confidence 设为 0.0。"""
+
+            response = client.chat.completions.create(
+                model=settings.LLM_MODEL_NAME,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.1,
+                max_tokens=200,
+                response_format={"type": "json_object"},
+            )
+
+            result = json.loads(response.choices[0].message.content)
+            if result.get("confidence", 0) > 0.5:
+                return (result["resolved_time"], result["confidence"])
+        except Exception as e:
+            logger.error(f"LLM 时间解析失败: {e}")
+
+        return None, 0.0
+
+
+# 单例
+time_parser = TimeParser()
+
+
+async def resolve_time(expr: str, context: Optional[dict] = None) -> Tuple[Optional[str], float]:
+    """便捷函数：解析时间表达式"""
+    return time_parser.resolve(expr, context)

--- a/家用备忘录智能体/backend/requirements.txt
+++ b/家用备忘录智能体/backend/requirements.txt
@@ -1,0 +1,34 @@
+# ===== 核心框架 =====
+fastapi==0.115.0
+uvicorn[standard]==0.30.0
+pydantic==2.9.0
+pydantic-settings==2.5.0
+
+# ===== 数据库 =====
+sqlalchemy==2.0.35
+aiomysql==0.2.0
+cryptography==43.0.0
+alembic==1.13.0
+
+# ===== 缓存/队列 =====
+redis==5.1.0
+
+# ===== LLM =====
+openai>=1.40.0
+httpx>=0.28.0
+
+# ===== 认证 =====
+python-jose[cryptography]>=3.3.0
+passlib[bcrypt]>=1.7.4
+
+# ===== 工具 =====
+python-dotenv>=1.0.0
+python-dateutil>=2.9.0
+pytz>=2024.0
+loguru>=0.7.0
+tenacity>=8.5.0
+aiofiles>=24.0.0
+
+# ===== 开发 =====
+pytest>=8.0.0
+pytest-asyncio>=0.24.0

--- a/家用备忘录智能体/docker-compose.yml
+++ b/家用备忘录智能体/docker-compose.yml
@@ -1,0 +1,61 @@
+version: "3.8"
+
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_USER=root
+      - DB_PASSWORD=family_memo_pwd
+      - DB_NAME=family_memo
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - WECHAT_APPID=${WECHAT_APPID:-}
+      - WECHAT_SECRET=${WECHAT_SECRET:-}
+      - LLM_API_KEY=${LLM_API_KEY:-}
+      - LLM_BASE_URL=${LLM_BASE_URL:-}
+      - LLM_MODEL_NAME=${LLM_MODEL_NAME:-}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-change-this-to-a-random-secret-key}
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    volumes:
+      - ./backend:/app
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: family_memo_pwd
+      MYSQL_DATABASE: family_memo
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+volumes:
+  mysql_data:
+  redis_data:

--- a/家用备忘录智能体/miniprogram/app.js
+++ b/家用备忘录智能体/miniprogram/app.js
@@ -1,0 +1,43 @@
+// app.js
+App({
+  globalData: {
+    token: '',
+    memberId: '',
+    hasFamily: false,
+    role: '',
+    familyInfo: null,
+  },
+
+  onLaunch() {
+    // 检查登录状态
+    const token = wx.getStorageSync('token');
+    if (token) {
+      this.globalData.token = token;
+      this.globalData.memberId = wx.getStorageSync('memberId');
+      this.globalData.hasFamily = wx.getStorageSync('hasFamily') === 'true';
+      this.globalData.role = wx.getStorageSync('role');
+    }
+  },
+
+  setLoginInfo(data) {
+    this.globalData.token = data.token;
+    this.globalData.memberId = data.member_id;
+    this.globalData.hasFamily = data.has_family;
+    this.globalData.role = data.role || '';
+    wx.setStorageSync('token', data.token);
+    wx.setStorageSync('memberId', data.member_id);
+    wx.setStorageSync('hasFamily', String(data.has_family));
+    wx.setStorageSync('role', data.role || '');
+  },
+
+  logout() {
+    this.globalData.token = '';
+    this.globalData.memberId = '';
+    this.globalData.hasFamily = false;
+    this.globalData.role = '';
+    wx.removeStorageSync('token');
+    wx.removeStorageSync('memberId');
+    wx.removeStorageSync('hasFamily');
+    wx.removeStorageSync('role');
+  },
+});

--- a/家用备忘录智能体/miniprogram/app.json
+++ b/家用备忘录智能体/miniprogram/app.json
@@ -1,0 +1,57 @@
+{
+  "pages": [
+    "pages/index/index",
+    "pages/chat/chat",
+    "pages/shopping/shopping",
+    "pages/payment/payment",
+    "pages/finance/finance",
+    "pages/vehicle/vehicle",
+    "pages/anniversary/anniversary",
+    "pages/profile/profile"
+  ],
+  "window": {
+    "navigationBarTitleText": "家庭备忘录",
+    "navigationBarBackgroundColor": "#ffffff",
+    "navigationBarTextStyle": "black",
+    "backgroundColor": "#f5f5f5"
+  },
+  "tabBar": {
+    "color": "#999999",
+    "selectedColor": "#07c160",
+    "backgroundColor": "#ffffff",
+    "borderStyle": "black",
+    "list": [
+      {
+        "pagePath": "pages/index/index",
+        "text": "首页",
+        "iconPath": "images/home.png",
+        "selectedIconPath": "images/home_active.png"
+      },
+      {
+        "pagePath": "pages/shopping/shopping",
+        "text": "购物",
+        "iconPath": "images/shop.png",
+        "selectedIconPath": "images/shop_active.png"
+      },
+      {
+        "pagePath": "pages/vehicle/vehicle",
+        "text": "车辆",
+        "iconPath": "images/car.png",
+        "selectedIconPath": "images/car_active.png"
+      },
+      {
+        "pagePath": "pages/chat/chat",
+        "text": "对话",
+        "iconPath": "images/chat.png",
+        "selectedIconPath": "images/chat_active.png"
+      },
+      {
+        "pagePath": "pages/profile/profile",
+        "text": "我的",
+        "iconPath": "images/me.png",
+        "selectedIconPath": "images/me_active.png"
+      }
+    ]
+  },
+  "sitemapLocation": "sitemap.json"
+}

--- a/家用备忘录智能体/miniprogram/app.wxss
+++ b/家用备忘录智能体/miniprogram/app.wxss
@@ -1,0 +1,134 @@
+/* 全局样式 */
+page {
+  background-color: #f5f5f5;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  color: #333;
+  box-sizing: border-box;
+}
+
+/* 通用卡片 */
+.card {
+  background: #fff;
+  border-radius: 12rpx;
+  padding: 30rpx;
+  margin: 20rpx 30rpx;
+  box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.06);
+}
+
+/* 按钮 */
+.btn-primary {
+  background-color: #07c160;
+  color: #fff;
+  border-radius: 8rpx;
+  padding: 20rpx 40rpx;
+  font-size: 28rpx;
+  text-align: center;
+  border: none;
+}
+
+.btn-primary:active {
+  background-color: #06ad56;
+}
+
+.btn-secondary {
+  background-color: #fff;
+  color: #07c160;
+  border: 2rpx solid #07c160;
+  border-radius: 8rpx;
+  padding: 18rpx 38rpx;
+  font-size: 28rpx;
+  text-align: center;
+}
+
+/* 输入框 */
+.input-field {
+  background: #f8f8f8;
+  border-radius: 8rpx;
+  padding: 20rpx 24rpx;
+  font-size: 28rpx;
+  border: 2rpx solid #eee;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input-field:focus {
+  border-color: #07c160;
+}
+
+/* 标签 */
+.tag {
+  display: inline-block;
+  padding: 4rpx 16rpx;
+  border-radius: 6rpx;
+  font-size: 22rpx;
+  margin-right: 8rpx;
+}
+
+.tag-green {
+  background: #e8f8ee;
+  color: #07c160;
+}
+
+.tag-yellow {
+  background: #fef7e0;
+  color: #f5a623;
+}
+
+.tag-red {
+  background: #fde8e8;
+  color: #e74c3c;
+}
+
+.tag-gray {
+  background: #f0f0f0;
+  color: #999;
+}
+
+/* 空状态 */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 100rpx 0;
+  color: #999;
+  font-size: 28rpx;
+}
+
+/* 加载 */
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40rpx;
+}
+
+/* 列表项 */
+.list-item {
+  display: flex;
+  align-items: center;
+  padding: 24rpx 30rpx;
+  background: #fff;
+  border-bottom: 1rpx solid #f0f0f0;
+}
+
+.list-item:last-child {
+  border-bottom: none;
+}
+
+/* 头部标题 */
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24rpx 30rpx 16rpx;
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #333;
+}
+
+.section-header .more {
+  font-size: 24rpx;
+  color: #999;
+  font-weight: normal;
+}

--- a/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.js
+++ b/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.js
@@ -1,0 +1,97 @@
+// pages/anniversary/anniversary.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    anniversaries: [],
+    wishList: [],
+    loading: false,
+    showAdd: false,
+    showWish: false,
+    newAnniversary: { name: '', date: '', reminder_days: 7 },
+    newWish: { content: '', category: '' },
+  },
+
+  onShow() {
+    this.loadData();
+  },
+
+  async loadData() {
+    this.setData({ loading: true });
+    try {
+      const [anniversaries, wishList] = await Promise.all([
+        api.getAnniversaries(),
+        api.getWishList(),
+      ]);
+      this.setData({ anniversaries, wishList, loading: false });
+    } catch (e) {
+      this.setData({ loading: false });
+    }
+  },
+
+  showAddModal() {
+    this.setData({ showAdd: true, newAnniversary: { name: '', date: '', reminder_days: 7 } });
+  },
+
+  async onAdd() {
+    if (!this.data.newAnniversary.name || !this.data.newAnniversary.date) {
+      wx.showToast({ title: '请填写完整信息', icon: 'none' });
+      return;
+    }
+    try {
+      await api.createAnniversary(this.data.newAnniversary);
+      this.setData({ showAdd: false });
+      wx.showToast({ title: '添加成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '添加失败', icon: 'none' });
+    }
+  },
+
+  async onDelete(e) {
+    const id = e.currentTarget.dataset.id;
+    wx.showModal({
+      title: '确认删除',
+      content: '确定删除这个纪念日？',
+      success: async (res) => {
+        if (res.confirm) {
+          try {
+            await api.deleteAnniversary(id);
+            wx.showToast({ title: '已删除', icon: 'success' });
+            this.loadData();
+          } catch (e) {
+            wx.showToast({ title: '删除失败', icon: 'none' });
+          }
+        }
+      },
+    });
+  },
+
+  showWishModal() {
+    this.setData({ showWish: true, newWish: { content: '', category: '' } });
+  },
+
+  async onAddWish() {
+    if (!this.data.newWish.content) {
+      wx.showToast({ title: '请输入愿望内容', icon: 'none' });
+      return;
+    }
+    try {
+      await api.addWishItem(this.data.newWish);
+      this.setData({ showWish: false });
+      wx.showToast({ title: '添加成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '添加失败', icon: 'none' });
+    }
+  },
+
+  getDaysUntil(dateStr) {
+    const today = new Date();
+    const target = new Date(dateStr);
+    target.setFullYear(today.getFullYear());
+    if (target < today) target.setFullYear(today.getFullYear() + 1);
+    const diff = Math.ceil((target - today) / (1000 * 60 * 60 * 24));
+    return diff;
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.wxml
+++ b/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.wxml
@@ -1,0 +1,72 @@
+<view class="page">
+  <view class="section-header">
+    <text>🎉 纪念日/生日</text>
+    <text class="more" bindtap="showAddModal">+ 添加</text>
+  </view>
+
+  <view class="loading" wx:if="{{loading}}"><text>加载中...</text></view>
+
+  <view wx:for="{{anniversaries}}" wx:key="id" class="card anniversary-item">
+    <view class="anni-header">
+      <text class="anni-name">{{item.name}}</text>
+      <view class="tag tag-green" wx:if="{{item.is_active}}">剩余{{getDaysUntil(item.date)}}天</view>
+    </view>
+    <view class="anni-date">{{item.date}}</view>
+    <view class="anni-plans" wx:if="{{item.plans && item.plans.length > 0}}">
+      <text class="plan-label">安排：</text>
+      <text wx:for="{{item.plans}}" wx:key="id">{{item.content}} </text>
+    </view>
+    <view class="anni-actions">
+      <button class="btn-secondary btn-sm" bindtap="onDelete" data-id="{{item.id}}">删除</button>
+    </view>
+  </view>
+
+  <view class="empty-state" wx:if="{{!loading && anniversaries.length === 0}}">
+    <text>暂无纪念日</text>
+  </view>
+
+  <!-- 愿望清单 -->
+  <view class="section-header">
+    <text>🎁 喜好愿望</text>
+    <text class="more" bindtap="showWishModal">+ 添加</text>
+  </view>
+
+  <view wx:for="{{wishList}}" wx:key="id" class="card wish-item">
+    <view class="wish-header">
+      <text class="wish-content">{{item.content}}</text>
+      <text class="wish-category tag tag-gray">{{item.category || '其他'}}</text>
+    </view>
+    <view class="wish-source">{{item.source === 'manual' ? '手动记录' : '系统推断'}}</view>
+  </view>
+
+  <view class="empty-state" wx:if="{{wishList.length === 0}}">
+    <text>暂无愿望记录</text>
+  </view>
+
+  <!-- 添加弹窗 -->
+  <view wx:if="{{showAdd}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">添加纪念日</view>
+      <input class="input-field" placeholder="名称（如：结婚纪念日）" bindinput="e => this.setData({'newAnniversary.name': e.detail.value})" />
+      <input class="input-field" placeholder="日期（如：2026-09-15）" bindinput="e => this.setData({'newAnniversary.date': e.detail.value})" />
+      <input class="input-field" placeholder="提前几天提醒（默认7天）" type="number" bindinput="e => this.setData({'newAnniversary.reminder_days': parseInt(e.detail.value) || 7})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showAdd: false})">取消</button>
+        <button class="btn-primary" bindtap="onAdd">添加</button>
+      </view>
+    </view>
+  </view>
+
+  <!-- 愿望弹窗 -->
+  <view wx:if="{{showWish}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">添加愿望</view>
+      <input class="input-field" placeholder="想要什么？" bindinput="e => this.setData({'newWish.content': e.detail.value})" />
+      <input class="input-field" placeholder="分类（可选）" bindinput="e => this.setData({'newWish.category': e.detail.value})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showWish: false})">取消</button>
+        <button class="btn-primary" bindtap="onAddWish">添加</button>
+      </view>
+    </view>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.wxss
+++ b/家用备忘录智能体/miniprogram/pages/anniversary/anniversary.wxss
@@ -1,0 +1,59 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+.anni-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.anni-name {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.anni-date {
+  font-size: 26rpx;
+  color: #999;
+  margin-bottom: 8rpx;
+}
+
+.anni-plans {
+  font-size: 24rpx;
+  color: #666;
+  margin-bottom: 12rpx;
+}
+
+.plan-label {
+  color: #999;
+}
+
+.anni-actions {
+  display: flex;
+  gap: 16rpx;
+}
+
+.wish-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.wish-content {
+  font-size: 28rpx;
+  flex: 1;
+  margin-right: 12rpx;
+}
+
+.wish-category {
+  flex-shrink: 0;
+}
+
+.wish-source {
+  font-size: 22rpx;
+  color: #ccc;
+  margin-top: 4rpx;
+}

--- a/家用备忘录智能体/miniprogram/pages/chat/chat.js
+++ b/家用备忘录智能体/miniprogram/pages/chat/chat.js
@@ -1,0 +1,62 @@
+// pages/chat/chat.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    messages: [
+      { role: 'bot', content: '你好！我是家庭备忘录助手。你可以跟我说：\n• "下周三交电费"\n• "买牛奶"\n• "今天加油花了300"\n• "记一下结婚纪念日"\n• "这月花了多少钱"', time: '' },
+    ],
+    inputValue: '',
+    sending: false,
+    hasFamily: false,
+  },
+
+  onShow() {
+    const app = getApp();
+    this.setData({ hasFamily: app.globalData.hasFamily });
+  },
+
+  onInput(e) {
+    this.setData({ inputValue: e.detail.value });
+  },
+
+  async sendMessage() {
+    const msg = this.data.inputValue.trim();
+    if (!msg || this.data.sending) return;
+
+    // 检查是否已加入家庭
+    const app = getApp();
+    if (!app.globalData.hasFamily) {
+      wx.showToast({ title: '请先加入家庭空间', icon: 'none' });
+      return;
+    }
+
+    this.setData({ inputValue: '', sending: true });
+
+    // 添加用户消息
+    const now = new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+    this.data.messages.push({ role: 'user', content: msg, time: now });
+    this.setData({ messages: this.data.messages });
+
+    try {
+      const res = await api.sendMessage(msg);
+      const replyTime = new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+      this.data.messages.push({ role: 'bot', content: res.reply, time: replyTime, needConfirm: res.need_confirm });
+      this.setData({ messages: this.data.messages });
+    } catch (e) {
+      this.data.messages.push({ role: 'bot', content: '抱歉，处理时出了点问题，请稍后重试。', time: '' });
+      this.setData({ messages: this.data.messages });
+    }
+
+    this.setData({ sending: false });
+    this.scrollToBottom();
+  },
+
+  scrollToBottom() {
+    setTimeout(() => {
+      wx.createSelectorQuery().select('#chat-list').boundingClientRect(rect => {
+        wx.pageScrollTo({ scrollTop: rect.height });
+      }).exec();
+    }, 100);
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/chat/chat.wxml
+++ b/家用备忘录智能体/miniprogram/pages/chat/chat.wxml
@@ -1,0 +1,20 @@
+<view class="page">
+  <scroll-view id="chat-list" class="chat-list" scroll-y scroll-with-animation>
+    <view class="message-item {{item.role === 'user' ? 'user-msg' : 'bot-msg'}}" wx:for="{{messages}}" wx:key="index">
+      <view class="msg-bubble {{item.role}}">
+        <text class="msg-content">{{item.content}}</text>
+        <view class="msg-time" wx:if="{{item.time}}">{{item.time}}</view>
+      </view>
+    </view>
+    <view class="loading" wx:if="{{sending}}">
+      <text>思考中...</text>
+    </view>
+  </scroll-view>
+
+  <view class="input-area">
+    <input class="input-field" placeholder="说句话，比如：下周三交电费" value="{{inputValue}}" bindinput="onInput" confirm-type="send" bindconfirm="sendMessage" />
+    <button class="send-btn" bindtap="sendMessage" disabled="{{!inputValue.trim() || sending}}">
+      <text>发送</text>
+    </button>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/chat/chat.wxss
+++ b/家用备忘录智能体/miniprogram/pages/chat/chat.wxss
@@ -1,0 +1,101 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.chat-list {
+  flex: 1;
+  padding: 20rpx 30rpx;
+  overflow-y: auto;
+}
+
+.message-item {
+  margin-bottom: 24rpx;
+  display: flex;
+}
+
+.user-msg {
+  justify-content: flex-end;
+}
+
+.bot-msg {
+  justify-content: flex-start;
+}
+
+.msg-bubble {
+  max-width: 70%;
+  padding: 20rpx 24rpx;
+  border-radius: 12rpx;
+  font-size: 28rpx;
+  line-height: 1.6;
+  word-break: break-word;
+}
+
+.msg-bubble.user {
+  background: #07c160;
+  color: #fff;
+  border-bottom-right-radius: 4rpx;
+}
+
+.msg-bubble.bot {
+  background: #fff;
+  color: #333;
+  border-bottom-left-radius: 4rpx;
+  box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.06);
+}
+
+.msg-time {
+  font-size: 20rpx;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 8rpx;
+  text-align: right;
+}
+
+.msg-bubble.bot .msg-time {
+  color: #ccc;
+}
+
+.input-area {
+  display: flex;
+  align-items: center;
+  padding: 16rpx 30rpx;
+  background: #fff;
+  border-top: 1rpx solid #eee;
+  flex-shrink: 0;
+}
+
+.input-field {
+  flex: 1;
+  height: 72rpx;
+  background: #f5f5f5;
+  border-radius: 36rpx;
+  padding: 0 28rpx;
+  font-size: 28rpx;
+  border: none;
+}
+
+.send-btn {
+  width: 120rpx;
+  height: 72rpx;
+  background: #07c160;
+  color: #fff;
+  border-radius: 36rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 16rpx;
+  font-size: 28rpx;
+  border: none;
+  line-height: 72rpx;
+  padding: 0;
+}
+
+.send-btn:active {
+  background: #06ad56;
+}
+
+.send-btn[disabled] {
+  background: #ccc;
+}

--- a/家用备忘录智能体/miniprogram/pages/finance/finance.js
+++ b/家用备忘录智能体/miniprogram/pages/finance/finance.js
@@ -1,0 +1,66 @@
+// pages/finance/finance.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    stats: null,
+    records: [],
+    loading: false,
+    showAdd: false,
+    newRecord: { type: 'expense', amount: '', category: '', note: '', record_date: '' },
+  },
+
+  onShow() {
+    this.loadData();
+  },
+
+  async loadData() {
+    this.setData({ loading: true });
+    try {
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = now.getMonth() + 1;
+      const [stats, records] = await Promise.all([
+        api.getFinanceStats(year, month),
+        api.getFinanceRecords(year, month),
+      ]);
+      this.setData({ stats, records, loading: false });
+    } catch (e) {
+      this.setData({ loading: false });
+    }
+  },
+
+  showAddModal() {
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
+    this.setData({ showAdd: true, 'newRecord.record_date': dateStr });
+  },
+
+  async onAddRecord() {
+    if (!this.data.newRecord.amount) {
+      wx.showToast({ title: '请输入金额', icon: 'none' });
+      return;
+    }
+    try {
+      await api.createFinanceRecord({
+        ...this.data.newRecord,
+        amount: parseFloat(this.data.newRecord.amount),
+      });
+      this.setData({ showAdd: false });
+      wx.showToast({ title: '添加成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '添加失败', icon: 'none' });
+    }
+  },
+
+  categoryMap: {
+    'food': '餐饮', 'transport': '交通', 'shopping': '购物', 'entertainment': '娱乐',
+    'health': '健康', 'education': '教育', 'housing': '住房', 'utility': '水电',
+    'vehicle': '车辆', 'social': '社交', 'other': '其他',
+  },
+
+  getCategoryName(cat) {
+    return this.categoryMap[cat] || cat || '未分类';
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/finance/finance.wxml
+++ b/家用备忘录智能体/miniprogram/pages/finance/finance.wxml
@@ -1,0 +1,76 @@
+<view class="page">
+  <!-- 月度统计 -->
+  <view class="card" wx:if="{{stats}}">
+    <view class="card-header">
+      <text class="card-title">📊 {{stats.month}} 收支</text>
+    </view>
+    <view class="finance-row">
+      <view class="finance-item">
+        <text class="finance-label">支出</text>
+        <text class="finance-value expense">¥{{stats.total_expense.toFixed(2)}}</text>
+      </view>
+      <view class="finance-item">
+        <text class="finance-label">收入</text>
+        <text class="finance-value income">¥{{stats.total_income.toFixed(2)}}</text>
+      </view>
+    </view>
+
+    <!-- 分类支出 -->
+    <view class="category-section" wx:if="{{stats.by_category && Object.keys(stats.by_category).length > 0}}">
+      <view class="category-title">支出分类</view>
+      <view class="category-item" wx:for="{{Object.keys(stats.by_category)}}" wx:key="*this">
+        <text class="cat-name">{{item}}</text>
+        <view class="cat-bar-bg">
+          <view class="cat-bar" style="width: {{stats.by_category[item] / stats.total_expense * 100}}%"></view>
+        </view>
+        <text class="cat-amount">¥{{stats.by_category[item].toFixed(2)}}</text>
+      </view>
+    </view>
+  </view>
+
+  <!-- 添加按钮 -->
+  <view class="add-btn-wrap">
+    <button class="btn-primary add-btn" bindtap="showAddModal">+ 记一笔</button>
+  </view>
+
+  <!-- 记录列表 -->
+  <view class="section-header">收支明细</view>
+  <view class="loading" wx:if="{{loading}}"><text>加载中...</text></view>
+
+  <view wx:for="{{records}}" wx:key="id" class="card record-item">
+    <view class="record-header">
+      <text class="record-category">{{getCategoryName(item.category)}}</text>
+      <text class="record-amount {{item.type === 'expense' ? 'expense' : 'income'}}">
+        {{item.type === 'expense' ? '-' : '+'}}¥{{item.amount}}
+      </text>
+    </view>
+    <view class="record-info" wx:if="{{item.note}}">
+      <text>{{item.note}}</text>
+    </view>
+    <view class="record-date">{{item.record_date}}</view>
+  </view>
+
+  <view class="empty-state" wx:if="{{!loading && records.length === 0}}">
+    <text>本月暂无记录</text>
+  </view>
+
+  <!-- 添加弹窗 -->
+  <view wx:if="{{showAdd}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">记一笔</view>
+      <view class="radio-group">
+        <label class="radio-label" wx:for="{{[{v:'expense',l:'支出'},{v:'income',l:'收入'}]}}" wx:key="v">
+          <radio value="{{item.v}}" checked="{{newRecord.type === item.v}}" bindtap="e => this.setData({'newRecord.type': item.v})" />
+          <text>{{item.l}}</text>
+        </label>
+      </view>
+      <input class="input-field" placeholder="金额" type="digit" bindinput="e => this.setData({'newRecord.amount': e.detail.value})" />
+      <input class="input-field" placeholder="分类（如：餐饮、交通）" bindinput="e => this.setData({'newRecord.category': e.detail.value})" />
+      <input class="input-field" placeholder="备注" bindinput="e => this.setData({'newRecord.note': e.detail.value})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showAdd: false})">取消</button>
+        <button class="btn-primary" bindtap="onAddRecord">添加</button>
+      </view>
+    </view>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/finance/finance.wxss
+++ b/家用备忘录智能体/miniprogram/pages/finance/finance.wxss
@@ -1,0 +1,125 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+.finance-row {
+  display: flex;
+  justify-content: space-around;
+  text-align: center;
+  padding: 20rpx 0;
+}
+
+.finance-item {
+  flex: 1;
+}
+
+.finance-label {
+  display: block;
+  font-size: 24rpx;
+  color: #999;
+  margin-bottom: 8rpx;
+}
+
+.finance-value {
+  font-size: 36rpx;
+  font-weight: 700;
+  color: #333;
+}
+
+.finance-value.expense {
+  color: #e74c3c;
+}
+
+.finance-value.income {
+  color: #07c160;
+}
+
+.category-section {
+  margin-top: 20rpx;
+  padding-top: 20rpx;
+  border-top: 1rpx solid #f0f0f0;
+}
+
+.category-title {
+  font-size: 26rpx;
+  color: #666;
+  margin-bottom: 16rpx;
+}
+
+.category-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12rpx;
+  font-size: 24rpx;
+}
+
+.cat-name {
+  width: 100rpx;
+  color: #666;
+}
+
+.cat-bar-bg {
+  flex: 1;
+  height: 16rpx;
+  background: #f0f0f0;
+  border-radius: 8rpx;
+  margin: 0 16rpx;
+  overflow: hidden;
+}
+
+.cat-bar {
+  height: 100%;
+  background: #07c160;
+  border-radius: 8rpx;
+}
+
+.cat-amount {
+  width: 140rpx;
+  text-align: right;
+  color: #333;
+  font-weight: 500;
+}
+
+.add-btn-wrap {
+  padding: 20rpx 30rpx;
+}
+
+.add-btn {
+  width: 100%;
+}
+
+.record-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.record-category {
+  font-size: 28rpx;
+  font-weight: 500;
+}
+
+.record-amount {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.record-amount.expense {
+  color: #e74c3c;
+}
+
+.record-amount.income {
+  color: #07c160;
+}
+
+.record-info {
+  font-size: 24rpx;
+  color: #999;
+  margin-bottom: 8rpx;
+}
+
+.record-date {
+  font-size: 22rpx;
+  color: #ccc;
+}

--- a/家用备忘录智能体/miniprogram/pages/index/index.js
+++ b/家用备忘录智能体/miniprogram/pages/index/index.js
@@ -1,0 +1,109 @@
+// pages/index/index.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    hasFamily: false,
+    role: '',
+    roleLabel: '',
+    searchValue: '',
+    memoCount: 0,
+    todayMemos: [],
+    upcomingMemos: [],
+    overdueMemos: [],
+    monthlyExpense: 0,
+    monthlyIncome: 0,
+    activities: [],
+    quickEntries: [
+      { icon: '💬', name: '对话', url: '/pages/chat/chat' },
+      { icon: '🛒', name: '购物', url: '/pages/shopping/shopping' },
+      { icon: '💰', name: '缴费', url: '/pages/payment/payment' },
+      { icon: '🚗', name: '车辆', url: '/pages/vehicle/vehicle' },
+      { icon: '🎉', name: '纪念日', url: '/pages/anniversary/anniversary' },
+      { icon: '📊', name: '收支', url: '/pages/finance/finance' },
+    ],
+  },
+
+  onShow() {
+    const app = getApp();
+    if (app.globalData.token) {
+      const role = app.globalData.role || '';
+      const roleLabel = role === 'husband' ? '老公' : role === 'wife' ? '老婆' : '';
+      this.setData({
+        hasFamily: app.globalData.hasFamily,
+        role,
+        roleLabel,
+      });
+      if (app.globalData.hasFamily) {
+        this.loadData();
+      }
+    }
+  },
+
+  onSearchInput(e) {
+    this.setData({ searchValue: e.detail.value });
+  },
+
+  onSearch() {
+    const keyword = this.data.searchValue.trim();
+    if (keyword) {
+      wx.navigateTo({ url: '/pages/chat/chat' });
+    }
+  },
+
+  async loadData() {
+    try {
+      // 加载待办
+      const memos = await api.sendMessage('查一下我的待办');
+      if (memos && memos.data) {
+        const now = Date.now();
+        const overdue = [];
+        const today = [];
+        const upcoming = [];
+        memos.data.forEach(m => {
+          if (m.status === 'pending') {
+            const dueTime = new Date(m.due_time).getTime();
+            if (dueTime < now) overdue.push(m);
+            else if (dueTime < now + 86400000) today.push(m);
+            else upcoming.push(m);
+          }
+        });
+        this.setData({
+          memoCount: memos.data.length,
+          overdueMemos: overdue,
+          todayMemos: today,
+          upcomingMemos: upcoming,
+        });
+      }
+
+      // 加载月度收支
+      const stats = await api.getFinanceStats();
+      if (stats) {
+        this.setData({
+          monthlyExpense: stats.total_expense,
+          monthlyIncome: stats.total_income,
+        });
+      }
+
+      // 模拟动态流数据（后续从后端获取）
+      this.setData({
+        activities: [
+          { type: 'alert', text: '💡 车险将于9月15日到期', time: '系统提醒' },
+          { type: 'action', text: '📝 你有1条待办逾期', time: '刚刚' },
+          { type: 'action', text: '🛒 购物清单有3件待商榷', time: '系统提醒' },
+        ],
+      });
+    } catch (e) {
+      console.error('加载首页数据失败', e);
+    }
+  },
+
+  navigateTo(e) {
+    const url = e.currentTarget.dataset.url;
+    wx.navigateTo({ url });
+  },
+
+  goToChat() {
+    wx.switchTab({ url: '/pages/chat/chat' });
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/index/index.wxml
+++ b/家用备忘录智能体/miniprogram/pages/index/index.wxml
@@ -1,0 +1,101 @@
+<view class="page">
+  <!-- 未加入家庭 -->
+  <block wx:if="{{!hasFamily}}">
+    <view class="empty-state">
+      <text class="empty-icon">👨‍👩‍👧‍👦</text>
+      <text class="empty-text">请先创建或加入家庭空间</text>
+      <button class="btn-primary" bindtap="navigateTo" data-url="/pages/profile/profile">去设置</button>
+    </view>
+  </block>
+
+  <!-- 已加入家庭 -->
+  <block wx:else>
+    <!-- ① 顶部导航：搜索框 + 角色标识 -->
+    <view class="top-bar">
+      <view class="search-box">
+        <text class="search-icon">🔍</text>
+        <input class="search-input" placeholder="搜索备忘..." value="{{searchValue}}" bindinput="onSearchInput" bindconfirm="onSearch" />
+      </view>
+      <view class="role-badge" wx:if="{{roleLabel}}">
+        <text>{{roleLabel}}</text>
+      </view>
+    </view>
+
+    <!-- ② 今日待办 -->
+    <view class="card">
+      <view class="card-header">
+        <text class="card-title">📋 今日待办</text>
+        <text class="card-count">{{overdueMemos.length + todayMemos.length}}项</text>
+      </view>
+
+      <view wx:if="{{overdueMemos.length > 0}}" class="memo-list">
+        <view class="memo-item memo-overdue" wx:for="{{overdueMemos}}" wx:key="id">
+          <view class="memo-tag tag-red">逾期</view>
+          <text class="memo-content">{{item.content}}</text>
+          <text class="memo-time">{{item.due_time}}</text>
+        </view>
+      </view>
+
+      <view wx:if="{{todayMemos.length > 0}}" class="memo-list">
+        <view class="memo-item" wx:for="{{todayMemos}}" wx:key="id">
+          <view class="memo-tag tag-yellow">今日</view>
+          <text class="memo-content">{{item.content}}</text>
+          <text class="memo-time">{{item.due_time}}</text>
+        </view>
+      </view>
+
+      <view wx:if="{{overdueMemos.length === 0 && todayMemos.length === 0}}" class="empty-state">
+        <text>今天没有待办事项 🎉</text>
+      </view>
+    </view>
+
+    <!-- ③ 关注动态（时间流） -->
+    <view class="card" wx:if="{{activities.length > 0}}">
+      <view class="card-header">
+        <text class="card-title">📢 关注动态</text>
+      </view>
+      <view class="activity-list">
+        <view class="activity-item" wx:for="{{activities}}" wx:key="index">
+          <text class="activity-text">{{item.text}}</text>
+          <text class="activity-time">{{item.time}}</text>
+        </view>
+      </view>
+    </view>
+
+    <!-- ④ 本月收支 -->
+    <view class="card">
+      <view class="card-header">
+        <text class="card-title">💰 本月收支</text>
+        <text class="card-more" bindtap="navigateTo" data-url="/pages/finance/finance">详情 ›</text>
+      </view>
+      <view class="finance-row">
+        <view class="finance-item">
+          <text class="finance-label">支出</text>
+          <text class="finance-value expense">¥{{monthlyExpense.toFixed(2)}}</text>
+        </view>
+        <view class="finance-item">
+          <text class="finance-label">收入</text>
+          <text class="finance-value income">¥{{monthlyIncome.toFixed(2)}}</text>
+        </view>
+        <view class="finance-item">
+          <text class="finance-label">结余</text>
+          <text class="finance-value">{{(monthlyIncome - monthlyExpense).toFixed(2)}}</text>
+        </view>
+      </view>
+    </view>
+
+    <!-- ⑤ 快捷入口 -->
+    <view class="quick-entries">
+      <view class="quick-item" wx:for="{{quickEntries}}" wx:key="name" bindtap="navigateTo" data-url="{{item.url}}">
+        <text class="quick-icon">{{item.icon}}</text>
+        <text class="quick-name">{{item.name}}</text>
+      </view>
+    </view>
+
+    <!-- ⑥ 底部对话入口 -->
+    <view class="chat-entry" bindtap="goToChat">
+      <text>💬 说句话记录事情</text>
+      <text class="arrow">›</text>
+    </view>
+  </block>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/index/index.wxss
+++ b/家用备忘录智能体/miniprogram/pages/index/index.wxss
@@ -1,0 +1,219 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+/* 顶部导航 */
+.top-bar {
+  display: flex;
+  align-items: center;
+  padding: 16rpx 30rpx;
+  background: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.search-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  background: #f5f5f5;
+  border-radius: 36rpx;
+  padding: 0 24rpx;
+  height: 64rpx;
+}
+
+.search-icon {
+  font-size: 28rpx;
+  margin-right: 12rpx;
+}
+
+.search-input {
+  flex: 1;
+  font-size: 26rpx;
+  height: 64rpx;
+}
+
+.role-badge {
+  background: #07c160;
+  color: #fff;
+  font-size: 22rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 20rpx;
+  margin-left: 16rpx;
+  flex-shrink: 0;
+}
+
+.empty-icon {
+  font-size: 80rpx;
+  margin-bottom: 20rpx;
+}
+
+.empty-text {
+  margin-bottom: 30rpx;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20rpx;
+}
+
+.card-title {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.card-count {
+  font-size: 24rpx;
+  color: #999;
+}
+
+.card-more {
+  font-size: 24rpx;
+  color: #07c160;
+}
+
+.memo-list {
+  margin-top: 10rpx;
+}
+
+.memo-item {
+  display: flex;
+  align-items: center;
+  padding: 16rpx 0;
+  border-bottom: 1rpx solid #f5f5f5;
+  font-size: 28rpx;
+}
+
+.memo-item:last-child {
+  border-bottom: none;
+}
+
+.memo-overdue {
+  background: #fff5f5;
+  margin: 0 -30rpx;
+  padding: 16rpx 30rpx;
+}
+
+.memo-tag {
+  margin-right: 12rpx;
+  flex-shrink: 0;
+}
+
+.memo-content {
+  flex: 1;
+  color: #333;
+}
+
+.memo-time {
+  font-size: 24rpx;
+  color: #999;
+  margin-left: 12rpx;
+}
+
+/* 动态流 */
+.activity-list {
+  margin-top: 8rpx;
+}
+
+.activity-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14rpx 0;
+  border-bottom: 1rpx solid #f5f5f5;
+  font-size: 26rpx;
+}
+
+.activity-item:last-child {
+  border-bottom: none;
+}
+
+.activity-text {
+  flex: 1;
+  color: #333;
+}
+
+.activity-time {
+  font-size: 22rpx;
+  color: #999;
+  margin-left: 16rpx;
+  flex-shrink: 0;
+}
+
+.finance-row {
+  display: flex;
+  justify-content: space-around;
+  text-align: center;
+  padding: 10rpx 0;
+}
+
+.finance-item {
+  flex: 1;
+}
+
+.finance-label {
+  display: block;
+  font-size: 24rpx;
+  color: #999;
+  margin-bottom: 8rpx;
+}
+
+.finance-value {
+  font-size: 32rpx;
+  font-weight: 600;
+  color: #333;
+}
+
+.finance-value.expense {
+  color: #e74c3c;
+}
+
+.finance-value.income {
+  color: #07c160;
+}
+
+.quick-entries {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 20rpx;
+  margin: 20rpx 0;
+}
+
+.quick-item {
+  width: 33.33%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20rpx 0;
+}
+
+.quick-icon {
+  font-size: 48rpx;
+  margin-bottom: 8rpx;
+}
+
+.quick-name {
+  font-size: 24rpx;
+  color: #666;
+}
+
+.chat-entry {
+  margin: 20rpx 30rpx;
+  background: #07c160;
+  color: #fff;
+  border-radius: 48rpx;
+  padding: 24rpx 40rpx;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 28rpx;
+  box-shadow: 0 4rpx 16rpx rgba(7, 193, 96, 0.3);
+}
+
+.chat-entry .arrow {
+  font-size: 32rpx;
+  color: rgba(255, 255, 255, 0.8);
+}

--- a/家用备忘录智能体/miniprogram/pages/payment/payment.js
+++ b/家用备忘录智能体/miniprogram/pages/payment/payment.js
@@ -1,0 +1,46 @@
+// pages/payment/payment.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    items: [],
+    records: [],
+    loading: false,
+  },
+
+  onShow() {
+    this.loadData();
+  },
+
+  async loadData() {
+    this.setData({ loading: true });
+    try {
+      const items = await api.getPaymentItems();
+      this.setData({ items, loading: false });
+    } catch (e) {
+      this.setData({ loading: false });
+      wx.showToast({ title: '加载失败', icon: 'none' });
+    }
+  },
+
+  async onMarkPaid(e) {
+    const id = e.currentTarget.dataset.id;
+    wx.showModal({
+      title: '标记已缴费',
+      content: '确认已缴纳？',
+      success: async (res) => {
+        if (res.confirm) {
+          try {
+            const now = new Date();
+            const dateStr = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
+            await api.createPaymentRecord({ payment_item_id: id, actual_amount: 0, paid_date: dateStr });
+            wx.showToast({ title: '已记录', icon: 'success' });
+            this.loadData();
+          } catch (e) {
+            wx.showToast({ title: '操作失败', icon: 'none' });
+          }
+        }
+      },
+    });
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/payment/payment.wxml
+++ b/家用备忘录智能体/miniprogram/pages/payment/payment.wxml
@@ -1,0 +1,25 @@
+<view class="page">
+  <view class="section-header">缴费项目</view>
+
+  <view class="loading" wx:if="{{loading}}"><text>加载中...</text></view>
+
+  <view wx:for="{{items}}" wx:key="id" class="card payment-item">
+    <view class="payment-header">
+      <text class="payment-name">{{item.name === 'water' ? '💧 水费' : item.name === 'electric' ? '⚡ 电费' : item.name === 'gas' ? '🔥 燃气费' : '🏠 物业费'}}</text>
+      <view class="tag {{item.is_active ? 'tag-green' : 'tag-gray'}}">{{item.is_active ? '已启用' : '已停用'}}</view>
+    </view>
+    <view class="payment-info">
+      <text>频率：{{item.frequency === 'monthly' ? '每月' : '每半年'}}</text>
+      <text>提醒日：每月{{item.reminder_day}}日</text>
+    </view>
+    <view class="payment-info">
+      <text>提前{{item.advance_days}}天提醒</text>
+      <text wx:if="{{item.estimated_amount}}">预估：¥{{item.estimated_amount}}</text>
+    </view>
+    <button class="btn-primary btn-sm" bindtap="onMarkPaid" data-id="{{item.id}}">标记已缴费</button>
+  </view>
+
+  <view class="empty-state" wx:if="{{!loading && items.length === 0}}">
+    <text>暂无缴费项目</text>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/payment/payment.wxss
+++ b/家用备忘录智能体/miniprogram/pages/payment/payment.wxss
@@ -1,0 +1,28 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+.payment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16rpx;
+}
+
+.payment-name {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.payment-info {
+  display: flex;
+  justify-content: space-between;
+  font-size: 26rpx;
+  color: #666;
+  margin-bottom: 8rpx;
+}
+
+.payment-item .btn-sm {
+  margin-top: 16rpx;
+  width: 100%;
+}

--- a/家用备忘录智能体/miniprogram/pages/profile/profile.js
+++ b/家用备忘录智能体/miniprogram/pages/profile/profile.js
@@ -1,0 +1,142 @@
+// pages/profile/profile.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    loggedIn: false,
+    member: null,
+    family: null,
+    inviteCode: '',
+    showCreateFamily: false,
+    showJoinFamily: false,
+    familyName: '我的家庭',
+    joinCode: '',
+    role: 'husband',
+    joinRole: 'wife',
+  },
+
+  onShow() {
+    this.checkLogin();
+  },
+
+  checkLogin() {
+    const app = getApp();
+    const token = app.globalData.token;
+    if (token) {
+      this.setData({ loggedIn: true });
+      this.loadData();
+    } else {
+      this.setData({ loggedIn: false });
+    }
+  },
+
+  async loadData() {
+    try {
+      const me = await api.getMe();
+      const family = await api.getFamilyInfo();
+      this.setData({
+        member: me,
+        family: family,
+        inviteCode: family.invite_code || '',
+      });
+    } catch (e) {
+      console.error('加载数据失败', e);
+    }
+  },
+
+  // 微信登录
+  wxLogin() {
+    wx.login({
+      success: async (res) => {
+        if (res.code) {
+          try {
+            const data = await api.login(res.code);
+            const app = getApp();
+            app.setLoginInfo(data);
+            this.setData({ loggedIn: true });
+            this.loadData();
+
+            if (!data.has_family) {
+              wx.showModal({
+                title: '加入家庭',
+                content: '你还没有家庭空间，创建或加入一个？',
+                confirmText: '创建家庭',
+                cancelText: '加入家庭',
+                success: (res) => {
+                  if (res.confirm) {
+                    this.setData({ showCreateFamily: true });
+                  } else {
+                    this.setData({ showJoinFamily: true });
+                  }
+                },
+              });
+            }
+          } catch (e) {
+            wx.showToast({ title: '登录失败', icon: 'none' });
+          }
+        }
+      },
+    });
+  },
+
+  // 创建家庭
+  async onCreateFamily() {
+    try {
+      const data = await api.createFamily(this.data.familyName, this.data.role);
+      const app = getApp();
+      app.globalData.hasFamily = true;
+      app.globalData.role = this.data.role;
+      this.setData({
+        showCreateFamily: false,
+        family: data,
+        inviteCode: data.invite_code,
+      });
+      wx.showToast({ title: '创建成功', icon: 'success' });
+      // 复制邀请码
+      wx.setClipboardData({ data: data.invite_code });
+    } catch (e) {
+      wx.showToast({ title: '创建失败', icon: 'none' });
+    }
+  },
+
+  // 加入家庭
+  async onJoinFamily() {
+    try {
+      const data = await api.joinFamily(this.data.joinCode, this.data.joinRole);
+      const app = getApp();
+      app.globalData.hasFamily = true;
+      app.globalData.role = this.data.joinRole;
+      this.setData({ showJoinFamily: false });
+      wx.showToast({ title: '加入成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '邀请码无效或已过期', icon: 'none' });
+    }
+  },
+
+  // 刷新邀请码
+  async onRefreshCode() {
+    try {
+      const data = await api.refreshInviteCode();
+      this.setData({ inviteCode: data.invite_code });
+      wx.setClipboardData({ data: data.invite_code });
+      wx.showToast({ title: '已复制新邀请码', icon: 'success' });
+    } catch (e) {
+      wx.showToast({ title: '刷新失败', icon: 'none' });
+    }
+  },
+
+  logout() {
+    wx.showModal({
+      title: '退出登录',
+      content: '确定退出登录？',
+      success: (res) => {
+        if (res.confirm) {
+          const app = getApp();
+          app.logout();
+          this.setData({ loggedIn: false, member: null, family: null });
+        }
+      },
+    });
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/profile/profile.wxml
+++ b/家用备忘录智能体/miniprogram/pages/profile/profile.wxml
@@ -1,0 +1,92 @@
+<view class="page">
+  <!-- 未登录 -->
+  <block wx:if="{{!loggedIn}}">
+    <view class="login-container">
+      <view class="login-icon">👨‍👩‍👧‍👦</view>
+      <view class="login-title">家庭备忘录</view>
+      <view class="login-desc">记录家庭大小事，夫妻共享不遗漏</view>
+      <button class="btn-primary login-btn" bindtap="wxLogin">微信登录</button>
+    </view>
+  </block>
+
+  <!-- 已登录 -->
+  <block wx:else>
+    <!-- 用户信息 -->
+    <view class="card user-card">
+      <view class="user-avatar">{{member && member.nickname ? member.nickname[0] : '?'}}</view>
+      <view class="user-info">
+        <view class="user-name">{{member && member.nickname || '用户'}}</view>
+        <view class="user-role">{{member && member.role === 'husband' ? '老公' : '老婆'}}</view>
+      </view>
+    </view>
+
+    <!-- 家庭信息 -->
+    <view class="card">
+      <view class="section-title">家庭空间</view>
+      <view wx:if="{{family}}">
+        <view class="info-row">
+          <text class="info-label">家庭名称</text>
+          <text class="info-value">{{family.name}}</text>
+        </view>
+        <view class="info-row">
+          <text class="info-label">家庭成员</text>
+          <text class="info-value">{{family.members && family.members.length || 0}}人</text>
+        </view>
+        <view class="info-row">
+          <text class="info-label">邀请码</text>
+          <text class="info-value code">{{inviteCode}}</text>
+        </view>
+        <button class="btn-secondary btn-small" bindtap="onRefreshCode">刷新邀请码</button>
+      </view>
+      <view wx:else class="empty-state">
+        <text>暂无家庭空间</text>
+        <button class="btn-primary" bindtap="wxLogin">创建家庭</button>
+      </view>
+    </view>
+
+    <!-- 设置 -->
+    <view class="card">
+      <view class="section-title">设置</view>
+      <view class="menu-item" bindtap="logout">
+        <text>退出登录</text>
+        <text class="arrow">›</text>
+      </view>
+    </view>
+  </block>
+
+  <!-- 创建家庭弹窗 -->
+  <view wx:if="{{showCreateFamily}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">创建家庭空间</view>
+      <input class="input-field" placeholder="家庭名称" value="{{familyName}}" bindinput="e => this.setData({familyName: e.detail.value})" />
+      <view class="radio-group">
+        <label class="radio-label" wx:for="{{[{v:'husband',l:'老公'},{v:'wife',l:'老婆'}]}}" wx:key="v">
+          <radio value="{{item.v}}" checked="{{role === item.v}}" bindtap="e => this.setData({role: item.v})" />
+          <text>{{item.l}}</text>
+        </label>
+      </view>
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showCreateFamily: false})">取消</button>
+        <button class="btn-primary" bindtap="onCreateFamily">创建</button>
+      </view>
+    </view>
+  </view>
+
+  <!-- 加入家庭弹窗 -->
+  <view wx:if="{{showJoinFamily}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">加入家庭空间</view>
+      <input class="input-field" placeholder="请输入邀请码" value="{{joinCode}}" bindinput="e => this.setData({joinCode: e.detail.value})" />
+      <view class="radio-group">
+        <label class="radio-label" wx:for="{{[{v:'husband',l:'老公'},{v:'wife',l:'老婆'}]}}" wx:key="v">
+          <radio value="{{item.v}}" checked="{{joinRole === item.v}}" bindtap="e => this.setData({joinRole: item.v})" />
+          <text>{{item.l}}</text>
+        </label>
+      </view>
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showJoinFamily: false})">取消</button>
+        <button class="btn-primary" bindtap="onJoinFamily">加入</button>
+      </view>
+    </view>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/profile/profile.wxss
+++ b/家用备忘录智能体/miniprogram/pages/profile/profile.wxss
@@ -1,0 +1,175 @@
+.page {
+  min-height: 100vh;
+  padding-bottom: 20rpx;
+}
+
+.login-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 200rpx;
+}
+
+.login-icon {
+  font-size: 120rpx;
+  margin-bottom: 30rpx;
+}
+
+.login-title {
+  font-size: 48rpx;
+  font-weight: 700;
+  color: #333;
+  margin-bottom: 16rpx;
+}
+
+.login-desc {
+  font-size: 28rpx;
+  color: #999;
+  margin-bottom: 60rpx;
+}
+
+.login-btn {
+  width: 400rpx;
+}
+
+.user-card {
+  display: flex;
+  align-items: center;
+}
+
+.user-avatar {
+  width: 100rpx;
+  height: 100rpx;
+  border-radius: 50%;
+  background: #07c160;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 40rpx;
+  margin-right: 24rpx;
+}
+
+.user-info {
+  flex: 1;
+}
+
+.user-name {
+  font-size: 32rpx;
+  font-weight: 600;
+  margin-bottom: 8rpx;
+}
+
+.user-role {
+  font-size: 24rpx;
+  color: #999;
+}
+
+.section-title {
+  font-size: 28rpx;
+  font-weight: 600;
+  margin-bottom: 20rpx;
+  color: #333;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 16rpx 0;
+  font-size: 28rpx;
+}
+
+.info-label {
+  color: #999;
+}
+
+.info-value {
+  color: #333;
+}
+
+.info-value.code {
+  color: #07c160;
+  font-weight: 600;
+  letter-spacing: 4rpx;
+}
+
+.btn-small {
+  margin-top: 16rpx;
+  font-size: 24rpx;
+  padding: 12rpx 24rpx;
+}
+
+.menu-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24rpx 0;
+  font-size: 28rpx;
+  border-bottom: 1rpx solid #f0f0f0;
+}
+
+.menu-item:last-child {
+  border-bottom: none;
+}
+
+.arrow {
+  font-size: 32rpx;
+  color: #ccc;
+}
+
+/* 模态框 */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 16rpx;
+  padding: 40rpx;
+  width: 600rpx;
+}
+
+.modal-title {
+  font-size: 32rpx;
+  font-weight: 600;
+  margin-bottom: 30rpx;
+  text-align: center;
+}
+
+.modal-btns {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 30rpx;
+}
+
+.modal-btns button {
+  flex: 1;
+  margin: 0 10rpx;
+  font-size: 28rpx;
+}
+
+.radio-group {
+  display: flex;
+  justify-content: center;
+  margin: 20rpx 0;
+}
+
+.radio-label {
+  display: flex;
+  align-items: center;
+  margin: 0 30rpx;
+  font-size: 28rpx;
+}
+
+.input-field {
+  margin-bottom: 16rpx;
+}

--- a/家用备忘录智能体/miniprogram/pages/shopping/shopping.js
+++ b/家用备忘录智能体/miniprogram/pages/shopping/shopping.js
@@ -1,0 +1,100 @@
+// pages/shopping/shopping.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    tabs: ['家用', '老公', '老婆'],
+    activeTab: 0,
+    items: [],
+    loading: false,
+    showAdd: false,
+    newItem: { name: '', list_type: 'household', estimated_price: '', purchase_reason: '' },
+    subTabs: ['全部', '待购买', '已购买'],
+    subActive: 0,
+  },
+
+  onShow() {
+    this.loadItems();
+  },
+
+  async loadItems() {
+    this.setData({ loading: true });
+    try {
+      const listTypes = ['household', 'husband', 'wife'];
+      const listType = listTypes[this.data.activeTab];
+      const statusMap = ['', 'pending', 'bought'];
+      const status = statusMap[this.data.subActive] || '';
+
+      const items = await api.getShoppingItems(listType, status);
+      this.setData({ items, loading: false });
+    } catch (e) {
+      this.setData({ loading: false });
+      wx.showToast({ title: '加载失败', icon: 'none' });
+    }
+  },
+
+  onTabChange(e) {
+    const index = e.currentTarget.dataset.index;
+    this.setData({ activeTab: parseInt(index) }, () => this.loadItems());
+  },
+
+  onSubTabChange(e) {
+    const index = e.currentTarget.dataset.index;
+    this.setData({ subActive: parseInt(index) }, () => this.loadItems());
+  },
+
+  showAddModal() {
+    const listTypes = ['household', 'husband', 'wife'];
+    this.setData({
+      showAdd: true,
+      'newItem.list_type': listTypes[this.data.activeTab],
+    });
+  },
+
+  async onAddItem() {
+    if (!this.data.newItem.name) {
+      wx.showToast({ title: '请输入物品名称', icon: 'none' });
+      return;
+    }
+    try {
+      await api.createShoppingItem(this.data.newItem);
+      this.setData({ showAdd: false, 'newItem.name': '', 'newItem.estimated_price': '', 'newItem.purchase_reason': '' });
+      wx.showToast({ title: '添加成功', icon: 'success' });
+      this.loadItems();
+    } catch (e) {
+      wx.showToast({ title: '添加失败', icon: 'none' });
+    }
+  },
+
+  async onAgree(e) {
+    const id = e.currentTarget.dataset.id;
+    const agreed = e.currentTarget.dataset.agreed === 'true';
+    try {
+      await api.agreeShoppingItem(id, !agreed);
+      this.loadItems();
+    } catch (e) {
+      wx.showToast({ title: '操作失败', icon: 'none' });
+    }
+  },
+
+  async onPurchase(e) {
+    const id = e.currentTarget.dataset.id;
+    wx.showModal({
+      title: '标记已购买',
+      content: '确认已购买？将自动记录到家庭收支。',
+      success: async (res) => {
+        if (res.confirm) {
+          try {
+            const now = new Date();
+            const dateStr = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
+            await api.purchaseShoppingItem(id, { actual_price: 0, purchase_method: '', purchase_date: dateStr });
+            wx.showToast({ title: '已记录', icon: 'success' });
+            this.loadItems();
+          } catch (e) {
+            wx.showToast({ title: '操作失败', icon: 'none' });
+          }
+        }
+      },
+    });
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/shopping/shopping.wxml
+++ b/家用备忘录智能体/miniprogram/pages/shopping/shopping.wxml
@@ -1,0 +1,63 @@
+<view class="page">
+  <!-- Tab 切换 -->
+  <view class="tabs">
+    <view class="tab {{activeTab === index ? 'active' : ''}}" wx:for="{{tabs}}" wx:key="index" data-index="{{index}}" bindtap="onTabChange">{{item}}</view>
+  </view>
+
+  <!-- 子Tab -->
+  <view class="sub-tabs">
+    <view class="sub-tab {{subActive === index ? 'active' : ''}}" wx:for="{{subTabs}}" wx:key="index" data-index="{{index}}" bindtap="onSubTabChange">{{item}}</view>
+  </view>
+
+  <!-- 添加按钮 -->
+  <view class="add-btn-wrap">
+    <button class="btn-primary add-btn" bindtap="showAddModal">+ 添加物品</button>
+  </view>
+
+  <!-- 列表 -->
+  <view class="loading" wx:if="{{loading}}"><text>加载中...</text></view>
+
+  <view wx:for="{{items}}" wx:key="id" class="card item-card">
+    <view class="item-header">
+      <text class="item-name">{{item.name}}</text>
+      <view class="item-tags">
+        <text class="tag tag-green" wx:if="{{item.status === 'bought'}}">已购买</text>
+        <text class="tag tag-yellow" wx:if="{{item.status === 'pending'}}">待购买</text>
+      </view>
+    </view>
+    <view class="item-info" wx:if="{{item.purchase_reason}}">
+      <text class="info-label">理由：</text>
+      <text>{{item.purchase_reason}}</text>
+    </view>
+    <view class="item-info" wx:if="{{item.estimated_price}}">
+      <text class="info-label">预估：</text>
+      <text>¥{{item.estimated_price}}</text>
+    </view>
+
+    <!-- 家用清单的同意按钮 -->
+    <view class="item-actions" wx:if="{{item.list_type === 'household' && item.status === 'pending'}}">
+      <button class="btn-secondary btn-sm" bindtap="onAgree" data-id="{{item.id}}" data-agreed="{{item.agreements && item.agreements.length > 0 && item.agreements[0].agreement ? 'true' : 'false'}}">
+        {{item.agreements && item.agreements.length > 0 && item.agreements[0].agreement ? '已同意 ✓' : '同意购买'}}
+      </button>
+      <button class="btn-secondary btn-sm" bindtap="onPurchase" data-id="{{item.id}}">标记已购买</button>
+    </view>
+  </view>
+
+  <view wx:if="{{!loading && items.length === 0}}" class="empty-state">
+    <text>暂无物品</text>
+  </view>
+
+  <!-- 添加弹窗 -->
+  <view wx:if="{{showAdd}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">添加物品</view>
+      <input class="input-field" placeholder="物品名称" bindinput="e => this.setData({'newItem.name': e.detail.value})" />
+      <input class="input-field" placeholder="预估价格" type="digit" bindinput="e => this.setData({'newItem.estimated_price': e.detail.value})" />
+      <input class="input-field" placeholder="购买理由" bindinput="e => this.setData({'newItem.purchase_reason': e.detail.value})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showAdd: false})">取消</button>
+        <button class="btn-primary" bindtap="onAddItem">添加</button>
+      </view>
+    </view>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/shopping/shopping.wxss
+++ b/家用备忘录智能体/miniprogram/pages/shopping/shopping.wxss
@@ -1,0 +1,105 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+.tabs {
+  display: flex;
+  background: #fff;
+  border-bottom: 1rpx solid #eee;
+}
+
+.tab {
+  flex: 1;
+  text-align: center;
+  padding: 24rpx 0;
+  font-size: 28rpx;
+  color: #666;
+  position: relative;
+}
+
+.tab.active {
+  color: #07c160;
+  font-weight: 600;
+}
+
+.tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60rpx;
+  height: 4rpx;
+  background: #07c160;
+  border-radius: 2rpx;
+}
+
+.sub-tabs {
+  display: flex;
+  padding: 16rpx 30rpx;
+  background: #fff;
+}
+
+.sub-tab {
+  padding: 8rpx 24rpx;
+  margin-right: 16rpx;
+  border-radius: 20rpx;
+  font-size: 24rpx;
+  color: #666;
+  background: #f5f5f5;
+}
+
+.sub-tab.active {
+  color: #fff;
+  background: #07c160;
+}
+
+.add-btn-wrap {
+  padding: 20rpx 30rpx;
+}
+
+.add-btn {
+  width: 100%;
+}
+
+.item-card {
+  margin: 16rpx 30rpx;
+}
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12rpx;
+}
+
+.item-name {
+  font-size: 30rpx;
+  font-weight: 600;
+}
+
+.item-tags {
+  display: flex;
+}
+
+.item-info {
+  font-size: 26rpx;
+  color: #666;
+  margin-bottom: 6rpx;
+}
+
+.info-label {
+  color: #999;
+}
+
+.item-actions {
+  display: flex;
+  margin-top: 16rpx;
+  gap: 16rpx;
+}
+
+.btn-sm {
+  font-size: 24rpx;
+  padding: 12rpx 24rpx;
+  flex: 1;
+}

--- a/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.js
+++ b/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.js
@@ -1,0 +1,98 @@
+// pages/vehicle/vehicle.js
+const api = require('../../utils/api');
+
+Page({
+  data: {
+    vehicle: null,
+    expenses: [],
+    license: [],
+    loading: false,
+    showEdit: false,
+    showExpense: false,
+    editForm: {},
+    expenseForm: { expense_type: 'fuel', amount: '', date: '', location: '' },
+    tabs: ['信息', '支出', '驾驶分'],
+    activeTab: 0,
+  },
+
+  onShow() {
+    this.loadData();
+  },
+
+  async loadData() {
+    this.setData({ loading: true });
+    try {
+      const [vehicle, expenses, license] = await Promise.all([
+        api.getVehicleInfo(),
+        api.getVehicleExpenses(),
+        api.getDrivingLicense(),
+      ]);
+      this.setData({ vehicle, expenses, license, loading: false });
+    } catch (e) {
+      this.setData({ loading: false });
+    }
+  },
+
+  onTabChange(e) {
+    const index = e.currentTarget.dataset.index;
+    this.setData({ activeTab: parseInt(index) });
+  },
+
+  showEditModal() {
+    const v = this.data.vehicle || {};
+    this.setData({
+      showEdit: true,
+      editForm: {
+        brand: v.brand || '',
+        model: v.model || '',
+        plate_number: v.plate_number || '',
+        insurance_expire: v.insurance_expire || '',
+        next_maintenance_date: v.next_maintenance_date || '',
+        next_inspection_date: v.next_inspection_date || '',
+        insurance_company: v.insurance_company || '',
+        maintenance_shop: v.maintenance_shop || '',
+        maintenance_phone: v.maintenance_phone || '',
+      },
+    });
+  },
+
+  async onSaveVehicle() {
+    try {
+      await api.updateVehicleInfo(this.data.editForm);
+      this.setData({ showEdit: false });
+      wx.showToast({ title: '保存成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '保存失败', icon: 'none' });
+    }
+  },
+
+  showExpenseModal() {
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
+    this.setData({ showExpense: true, 'expenseForm.date': dateStr });
+  },
+
+  async onAddExpense() {
+    if (!this.data.expenseForm.amount) {
+      wx.showToast({ title: '请输入金额', icon: 'none' });
+      return;
+    }
+    try {
+      await api.createVehicleExpense({
+        ...this.data.expenseForm,
+        amount: parseFloat(this.data.expenseForm.amount),
+      });
+      this.setData({ showExpense: false });
+      wx.showToast({ title: '记录成功', icon: 'success' });
+      this.loadData();
+    } catch (e) {
+      wx.showToast({ title: '记录失败', icon: 'none' });
+    }
+  },
+
+  expenseTypeMap: {
+    'fuel': '加油', 'charging': '充电', 'insurance': '保险',
+    'violation': '违章', 'maintenance': '保养', 'other': '其他',
+  },
+});

--- a/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.wxml
+++ b/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.wxml
@@ -1,0 +1,114 @@
+<view class="page">
+  <view class="tabs">
+    <view class="tab {{activeTab === index ? 'active' : ''}}" wx:for="{{tabs}}" wx:key="index" data-index="{{index}}" bindtap="onTabChange">{{item}}</view>
+  </view>
+
+  <!-- Tab 1: 车辆信息 -->
+  <block wx:if="{{activeTab === 0}}">
+    <view class="card" wx:if="{{vehicle && vehicle.brand}}">
+      <view class="vehicle-header">
+        <text class="vehicle-name">{{vehicle.brand}} {{vehicle.model}}</text>
+        <text class="vehicle-plate">{{vehicle.plate_number}}</text>
+      </view>
+      <view class="info-section">
+        <view class="info-row">
+          <text class="info-label">保险到期</text>
+          <text class="info-value {{vehicle.insurance_expire ? '' : 'gray'}}">{{vehicle.insurance_expire || '未设置'}}</text>
+        </view>
+        <view class="info-row">
+          <text class="info-label">下次保养</text>
+          <text class="info-value {{vehicle.next_maintenance_date ? '' : 'gray'}}">{{vehicle.next_maintenance_date || '未设置'}}</text>
+        </view>
+        <view class="info-row">
+          <text class="info-label">下次年检</text>
+          <text class="info-value {{vehicle.next_inspection_date ? '' : 'gray'}}">{{vehicle.next_inspection_date || '未设置'}}</text>
+        </view>
+        <view class="info-row">
+          <text class="info-label">保险公司</text>
+          <text class="info-value gray">{{vehicle.insurance_company || '未设置'}}</text>
+        </view>
+        <view class="info-row" wx:if="{{vehicle.maintenance_shop}}">
+          <text class="info-label">保养4S店</text>
+          <text class="info-value">{{vehicle.maintenance_shop}}</text>
+        </view>
+      </view>
+      <button class="btn-primary btn-sm" bindtap="showEditModal">编辑车辆信息</button>
+    </view>
+
+    <view class="card" wx:else>
+      <view class="empty-state">
+        <text>暂无车辆信息</text>
+        <button class="btn-primary" bindtap="showEditModal">添加车辆</button>
+      </view>
+    </view>
+  </block>
+
+  <!-- Tab 2: 支出记录 -->
+  <block wx:if="{{activeTab === 1}}">
+    <view class="add-btn-wrap">
+      <button class="btn-primary add-btn" bindtap="showExpenseModal">+ 记录支出</button>
+    </view>
+    <view class="loading" wx:if="{{loading}}"><text>加载中...</text></view>
+    <view wx:for="{{expenses}}" wx:key="id" class="card expense-item">
+      <view class="expense-header">
+        <text class="expense-type">{{expenseTypeMap[item.expense_type] || item.expense_type}}</text>
+        <text class="expense-amount">¥{{item.amount}}</text>
+      </view>
+      <view class="expense-info">{{item.date}} {{item.location}}</view>
+    </view>
+    <view class="empty-state" wx:if="{{!loading && expenses.length === 0}}"><text>暂无支出记录</text></view>
+  </block>
+
+  <!-- Tab 3: 驾驶分 -->
+  <block wx:if="{{activeTab === 2}}">
+    <view class="card">
+      <view class="points-row">
+        <text class="points-label">剩余分数</text>
+        <text class="points-value">{{license.length > 0 ? license[0].remaining_points : 12}} / 12</text>
+      </view>
+    </view>
+    <view wx:for="{{license}}" wx:key="id" class="card violation-item">
+      <view class="violation-header">
+        <text>{{item.reason}}</text>
+        <text class="tag-red">-{{item.deduction}}分</text>
+      </view>
+      <view class="violation-info">{{item.violation_date}} {{item.location}}</view>
+      <view wx:if="{{item.fine}}" class="violation-info">罚款：¥{{item.fine}}</view>
+    </view>
+    <view class="empty-state" wx:if="{{license.length === 0}}"><text>暂无违章记录</text></view>
+  </block>
+
+  <!-- 编辑弹窗 -->
+  <view wx:if="{{showEdit}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">车辆信息</view>
+      <input class="input-field" placeholder="品牌" value="{{editForm.brand}}" bindinput="e => this.setData({'editForm.brand': e.detail.value})" />
+      <input class="input-field" placeholder="型号" value="{{editForm.model}}" bindinput="e => this.setData({'editForm.model': e.detail.value})" />
+      <input class="input-field" placeholder="车牌号" value="{{editForm.plate_number}}" bindinput="e => this.setData({'editForm.plate_number': e.detail.value})" />
+      <input class="input-field" placeholder="保险到期日" value="{{editForm.insurance_expire}}" bindinput="e => this.setData({'editForm.insurance_expire': e.detail.value})" />
+      <input class="input-field" placeholder="下次保养日期" value="{{editForm.next_maintenance_date}}" bindinput="e => this.setData({'editForm.next_maintenance_date': e.detail.value})" />
+      <input class="input-field" placeholder="下次年检日期" value="{{editForm.next_inspection_date}}" bindinput="e => this.setData({'editForm.next_inspection_date': e.detail.value})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showEdit: false})">取消</button>
+        <button class="btn-primary" bindtap="onSaveVehicle">保存</button>
+      </view>
+    </view>
+  </view>
+
+  <!-- 支出弹窗 -->
+  <view wx:if="{{showExpense}}" class="modal-overlay">
+    <view class="modal">
+      <view class="modal-title">记录用车支出</view>
+      <picker mode="selector" range="{{['加油','充电','保险','违章','保养','其他']}}" bindchange="e => this.setData({'expenseForm.expense_type': ['fuel','charging','insurance','violation','maintenance','other'][e.detail.value]})">
+        <view class="picker">{{expenseTypeMap[expenseForm.expense_type]}}</view>
+      </picker>
+      <input class="input-field" placeholder="金额" type="digit" bindinput="e => this.setData({'expenseForm.amount': e.detail.value})" />
+      <input class="input-field" placeholder="日期" value="{{expenseForm.date}}" bindinput="e => this.setData({'expenseForm.date': e.detail.value})" />
+      <input class="input-field" placeholder="地点" bindinput="e => this.setData({'expenseForm.location': e.detail.value})" />
+      <view class="modal-btns">
+        <button class="btn-secondary" bindtap="e => this.setData({showExpense: false})">取消</button>
+        <button class="btn-primary" bindtap="onAddExpense">记录</button>
+      </view>
+    </view>
+  </view>
+</view>

--- a/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.wxss
+++ b/家用备忘录智能体/miniprogram/pages/vehicle/vehicle.wxss
@@ -1,0 +1,116 @@
+.page {
+  padding-bottom: 40rpx;
+}
+
+.vehicle-header {
+  margin-bottom: 20rpx;
+}
+
+.vehicle-name {
+  font-size: 34rpx;
+  font-weight: 700;
+  display: block;
+  margin-bottom: 6rpx;
+}
+
+.vehicle-plate {
+  font-size: 28rpx;
+  color: #07c160;
+  font-weight: 600;
+}
+
+.info-section {
+  margin-bottom: 16rpx;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 12rpx 0;
+  font-size: 26rpx;
+  border-bottom: 1rpx solid #f5f5f5;
+}
+
+.info-label {
+  color: #999;
+}
+
+.info-value {
+  color: #333;
+  font-weight: 500;
+}
+
+.info-value.gray {
+  color: #ccc;
+}
+
+.add-btn-wrap {
+  padding: 20rpx 30rpx;
+}
+
+.add-btn {
+  width: 100%;
+}
+
+.expense-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+}
+
+.expense-type {
+  font-size: 28rpx;
+  font-weight: 500;
+}
+
+.expense-amount {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: #e74c3c;
+}
+
+.expense-info {
+  font-size: 24rpx;
+  color: #999;
+}
+
+.points-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.points-label {
+  font-size: 28rpx;
+  color: #666;
+}
+
+.points-value {
+  font-size: 40rpx;
+  font-weight: 700;
+  color: #07c160;
+}
+
+.violation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8rpx;
+  font-size: 28rpx;
+}
+
+.violation-info {
+  font-size: 24rpx;
+  color: #999;
+  margin-bottom: 4rpx;
+}
+
+.picker {
+  padding: 20rpx;
+  background: #f8f8f8;
+  border-radius: 8rpx;
+  margin-bottom: 16rpx;
+  font-size: 28rpx;
+  border: 2rpx solid #eee;
+}

--- a/家用备忘录智能体/miniprogram/sitemap.json
+++ b/家用备忘录智能体/miniprogram/sitemap.json
@@ -1,0 +1,6 @@
+{
+  "rules": [{
+    "action": "allow",
+    "page": "*"
+  }]
+}

--- a/家用备忘录智能体/miniprogram/utils/api.js
+++ b/家用备忘录智能体/miniprogram/utils/api.js
@@ -1,0 +1,202 @@
+// 微信小程序 API 封装
+const BASE_URL = 'http://localhost:8000/api'; // 开发环境，生产环境替换为正式域名
+
+const request = (method, path, data = {}) => {
+  const app = getApp();
+  const token = app.globalData.token;
+
+  return new Promise((resolve, reject) => {
+    wx.request({
+      url: `${BASE_URL}${path}`,
+      method,
+      data,
+      header: {
+        'Content-Type': 'application/json',
+        'Authorization': token ? `Bearer ${token}` : '',
+      },
+      success(res) {
+        if (res.statusCode === 200 || res.statusCode === 201) {
+          resolve(res.data);
+        } else if (res.statusCode === 401) {
+          // token 过期，跳转登录
+          wx.navigateTo({ url: '/pages/profile/profile' });
+          reject(new Error('登录已过期'));
+        } else {
+          reject(new Error(res.data.detail || '请求失败'));
+        }
+      },
+      fail(err) {
+        reject(new Error('网络错误'));
+      },
+    });
+  });
+};
+
+module.exports = {
+  // ===== 认证 =====
+  login(code) {
+    return request('POST', '/auth/login', { code });
+  },
+
+  getMe() {
+    return request('GET', '/auth/me');
+  },
+
+  // ===== 家庭空间 =====
+  createFamily(name, role) {
+    return request('POST', '/family/create', { name, role });
+  },
+
+  joinFamily(inviteCode, role) {
+    return request('POST', '/family/join', { invite_code: inviteCode, role });
+  },
+
+  getFamilyInfo() {
+    return request('GET', '/family/info');
+  },
+
+  refreshInviteCode() {
+    return request('POST', '/family/refresh-code');
+  },
+
+  // ===== 对话 =====
+  sendMessage(message) {
+    return request('POST', '/chat', { message });
+  },
+
+  // ===== 缴费 =====
+  getPaymentItems() {
+    return request('GET', '/payment/items');
+  },
+
+  updatePaymentItem(id, data) {
+    return request('PUT', `/payment/items/${id}`, data);
+  },
+
+  getPaymentRecords() {
+    return request('GET', '/payment/records');
+  },
+
+  createPaymentRecord(data) {
+    return request('POST', '/payment/records', data);
+  },
+
+  // ===== 购物清单 =====
+  getShoppingItems(listType, status) {
+    let path = '/shopping/items';
+    const params = {};
+    if (listType) params.list_type = listType;
+    if (status) params.status = status;
+    const query = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
+    if (query) path += `?${query}`;
+    return request('GET', path);
+  },
+
+  createShoppingItem(data) {
+    return request('POST', '/shopping/items', data);
+  },
+
+  updateShoppingItem(id, data) {
+    return request('PUT', `/shopping/items/${id}`, data);
+  },
+
+  deleteShoppingItem(id) {
+    return request('DELETE', `/shopping/items/${id}`);
+  },
+
+  agreeShoppingItem(id, agreement) {
+    return request('POST', `/shopping/items/${id}/agree`, { agreement });
+  },
+
+  commentShoppingItem(id, content) {
+    return request('POST', `/shopping/items/${id}/comment`, { content });
+  },
+
+  purchaseShoppingItem(id, data) {
+    return request('POST', `/shopping/items/${id}/purchase`, data);
+  },
+
+  // ===== 收支记录 =====
+  getFinanceRecords(year, month, category) {
+    let path = '/finance/records';
+    const params = {};
+    if (year) params.year = year;
+    if (month) params.month = month;
+    if (category) params.category = category;
+    const query = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
+    if (query) path += `?${query}`;
+    return request('GET', path);
+  },
+
+  getFinanceStats(year, month) {
+    let path = '/finance/stats';
+    const params = {};
+    if (year) params.year = year;
+    if (month) params.month = month;
+    const query = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
+    if (query) path += `?${query}`;
+    return request('GET', path);
+  },
+
+  createFinanceRecord(data) {
+    return request('POST', '/finance/records', data);
+  },
+
+  // ===== 车辆管理 =====
+  getVehicleInfo() {
+    return request('GET', '/vehicle/info');
+  },
+
+  updateVehicleInfo(data) {
+    return request('PUT', '/vehicle/info', data);
+  },
+
+  getVehicleExpenses() {
+    return request('GET', '/vehicle/expenses');
+  },
+
+  createVehicleExpense(data) {
+    return request('POST', '/vehicle/expenses', data);
+  },
+
+  getDrivingLicense() {
+    return request('GET', '/vehicle/license');
+  },
+
+  addViolation(data) {
+    return request('POST', '/vehicle/license', data);
+  },
+
+  // ===== 纪念日 =====
+  getAnniversaries() {
+    return request('GET', '/anniversary/list');
+  },
+
+  createAnniversary(data) {
+    return request('POST', '/anniversary', data);
+  },
+
+  updateAnniversary(id, data) {
+    return request('PUT', `/anniversary/${id}`, data);
+  },
+
+  deleteAnniversary(id) {
+    return request('DELETE', `/anniversary/${id}`);
+  },
+
+  getAnniversaryPlans(id) {
+    return request('GET', `/anniversary/${id}/plans`);
+  },
+
+  createAnniversaryPlan(id, data) {
+    return request('POST', `/anniversary/${id}/plans`, data);
+  },
+
+  getWishList() {
+    return request('GET', '/anniversary/wish-list');
+  },
+
+  addWishItem(data) {
+    return request('POST', '/anniversary/wish-list', data);
+  },
+};

--- a/家用备忘录智能体/家用备忘录智能体设计文档.md
+++ b/家用备忘录智能体/家用备忘录智能体设计文档.md
@@ -1,0 +1,1042 @@
+# 家用备忘录智能体设计文档
+
+| 项目 | 内容 |
+|---|---|
+| 文档版本 | v1.1 |
+| 更新日期 | 2026-08-29 |
+| 文档状态 | 已评审修订 |
+| 适用范围 | 夫妻二人场景下的备忘录/提醒智能体 |
+
+---
+
+## 1. 项目背景与目标
+
+### 1.1 背景
+传统备忘录/待办 App 依赖用户主动打开、手动录入、手动分类,存在以下痛点:
+
+- 录入门槛高,夫妻之间常因"忘了说""说了忘了"产生摩擦
+- 家庭事务分散在两人手机上,缺乏统一视图
+- 缺乏"提醒该提醒谁""什么时候提醒"的智能判断
+- 语音/自然语言输入的口语化内容难以结构化
+
+### 1.2 目标
+构建一个可通过自然语言(文字/语音)交互的家庭备忘录智能体,实现:
+
+1. **零门槛录入**:说一句话就能生成结构化提醒("下周三提醒我交电费")
+2. **夫妻共享**:夫妻二人共用一个"记忆库",互相可见、可分配任务
+3. **主动提醒**:到点主动推送,并支持重要事项的多次/多端提醒
+4. **上下文理解**:支持多轮对话修改、模糊时间解析("下周"、"周末"、"你下班后")
+5. **多端接入**:App、微信小程序、智能音箱等可统一接入同一个智能体后端
+
+### 1.3 非目标(本期不做)
+- 不做复杂的项目管理/甘特图能力
+- 不做跨家庭的社交分享
+- 第一期不做端侧离线语音识别,依赖云端 ASR
+
+---
+
+## 2. 术语定义
+
+| 术语 | 含义 |
+|---|---|
+| 备忘条目(Memo Item) | 一条结构化的提醒/待办,包含时间、内容、负责人等 |
+| 家庭空间(Family Space) | 夫妻二人共享的备忘录集合,包含双方的提醒和任务分配 |
+| 意图(Intent) | 用户表达背后的操作类型,如"创建提醒""查询""取消" |
+| 记忆层(Memory Layer) | 智能体存储长期(家庭习惯、成员信息)与短期(当前对话上下文)信息的模块 |
+
+---
+
+## 3. 用户画像与典型场景
+
+### 3.1 用户画像
+- **老公**:家庭事务的主要参与者之一,关注财务(水电费、车贷)、家庭维修、外出事务等
+- **老婆**:家庭事务的另一核心参与者,关注采购、孩子教育、家庭聚会、健康管理等
+
+> 注:夫妻二人均拥有完整的创建、查看、修改、分配权限,当前版本暂不区分权限等级。
+
+### 3.2 典型场景
+
+**场景一:随手记**
+> 用户(语音):"提醒我明天下午三点去接孩子"
+> 智能体:创建提醒 [2026-08-26 15:00 接孩子],并追问"需要提前多久提醒你吗?"
+
+**场景二:模糊时间理解**
+> 用户:"周末记得交物业费"
+> 智能体:识别"周末"→ 结合家庭习惯(通常周六处理财务类事务)→ 建议 [2026-08-29 10:00],用户可确认或修改
+
+**场景三:夫妻协作分配**
+> 老婆:"提醒老公周五去交车检"
+> 智能体:创建提醒并标记负责人为"老公",老公手机收到推送
+
+**场景四:多轮修改**
+> 用户:"把刚才那条提醒改到晚上八点"
+> 智能体:结合上下文定位到"刚才那条",完成修改并复述确认
+
+**场景五:主动关怀式提醒**
+> 智能体识别到"老婆生日"临近(来自历史记忆或日历同步),主动提示:"下周二是老婆生日,要不要设置提醒或准备礼物?"
+
+---
+
+## 4. 需求分析
+
+### 4.1 功能性需求
+
+| 编号 | 功能 | 优先级 |
+|---|---|---|
+| F1 | 自然语言创建/修改/删除备忘条目 | P0 |
+| F2 | 模糊时间/相对时间解析(明天、下周、月底) | P0 |
+| F3 | 夫妻二人角色管理(创建、分配、接收) | P0 |
+| F4 | 到点主动推送提醒(App推送/短信/语音播报) | P0 |
+| F5 | 多轮对话上下文理解(指代消解,如"那条""刚才说的") | P0 |
+| F6 | 重复性提醒(每天/每周/每月/自定义周期) | P1 |
+| F7 | 语音输入与语音播报(智能音箱场景) | P1 |
+| F8 | 智能分类与标签(家务、财务、健康、学习) | P1 |
+| F9 | 主动建议(基于历史行为的提醒建议) | P2 |
+| F10 | 与第三方日历(如系统日历)双向同步 | P2 |
+
+### 4.2 已确认功能详情
+
+（以下功能经与用户确认后的具体设计）
+
+> **编号约定**：4.1 中的 F1-F10 为智能体核心能力；本节业务模块统一使用 **M1-M13** 编号，避免与 4.1 冲突。全文交叉引用均按此约定。
+
+**M1 周期性缴费提醒**
+| 项目 | 内容 |
+|---|---|
+| 包含项 | 水费、电费、燃气费、物业费 |
+| 频率 | 水费/电费/燃气费：每月；物业费：每半年 |
+| 负责人 | 老公 |
+| 提醒方式 | 到点推送，可设置提前提醒天数 |
+| 逾期策略 | 逾期每天推送一次，3天后升级频次，7天后通知老婆 |
+
+**M2 购物清单**
+购物清单分为**家用**和**个人使用**两大类：
+
+**家用购物清单（双方共享）**
+- 老公和老婆均可添加/编辑物品
+- 每项包含：物品名称、购买理由、双方的同意/不同意选择
+- 自动生成两个子清单：
+  - **已达成一致清单**：双方都同意购买的物品
+  - **待商榷清单**：有分歧的物品，供后续讨论
+- 支持分类、勾选已购买、物品前显示图标/图片
+- 每项可记录：**购买价格**、**购买方式**、**购买日期**
+
+**个人购物清单（各自独立）**
+- 分为「老公购物清单」和「老婆购物清单」
+- 各自只能维护自己的清单（增删改）
+- 但可在对方的购物项上添加建议/评论
+- 支持分类、勾选已购买、物品前显示图标/图片
+- 每项可记录：**购买价格**、**购买方式**、**购买日期**
+
+**M3 家庭收支记录**
+- 记录大额支出、共同开销（非专业记账，定位为备忘级别）
+- 支持备注说明（谁支付的、用途等）
+- 每月收支统计，以图表形式展示
+- **与购物清单关联**：购物清单中标记为"已购买"的项，自动归入家庭收支记录，无需重复录入
+- **与车辆支出关联**：充电、加油、车险、违章处理等用车支出自动归入
+- **与维修支出关联**：家庭维修/设备保养费用作为普通支出记录即可，不设独立功能模块
+
+**M4 车辆管理提醒**
+- **车辆信息**：品牌/型号/车牌号/购买日期
+- **保险信息**：保险到期日、保险公司
+- **保养信息**：常去4S店（名称/地址/联系人/联系电话）、下次保养提醒
+- **年检提醒**：下次年检日期
+- 用车支出记录：充电、加油、车险、违章处理，自动关联M3
+- 驾驶分管理：记录每次违章扣分及剩余分数
+- 周期提醒：保险/保养/年检自动推送
+
+**M5 家庭健康管理（重点功能）**
+
+**紧急信息速查（首页一键查看）：**
+- 每位成员独立：手机号码、血型、过敏药物、既往病史
+- 紧急联系人（2位）
+
+**周期性提醒（体检/牙科/眼科）：**
+- 每位成员独立设置，显示上次检查时间和下次提醒时间
+- 预约登记：填写医院/地址/预约时间/注意事项
+- 预约提醒：创建时 + 前一天 + 当天自动推送
+
+**病例/健康记录：**
+- 类型：病例/体检/手术/检查报告/疫苗/用药/中医/理疗/其他
+- 支持拍照上传附件（报告、药方等），记录医院/医生信息
+- 可按成员/类型筛选
+
+**日常健康追踪：**
+- 生理期记录：开始/结束日期、是否准时、症状（多选）、是否已吃止疼药
+- 心理健康：表情选择、备注、近7天趋势
+- 健康数据趋势（血压、体重等），支持手动记录
+
+**其他：**
+- 常去医院/医生信息
+- 保险信息（医疗险、重疾险、意外险等：险种、保额、到期日、理赔电话）
+
+**M6 社交/人情往来提醒**
+- 亲戚生日、朋友聚会、节日送礼等提醒
+- 随礼/红包记录（金额、日期、关系）
+- 提前提醒（如提前一周），可附地址/链接
+- **与家庭收支关联**：随礼/红包金额自动归入家庭收支记录
+
+**M7 纪念日/重要日期提醒**
+- 结婚纪念日、生日、恋爱纪念日、买房纪念日等
+- **与家庭收支关联**：纪念日相关支出自动归入家庭收支记录
+- **个人喜好/愿望记录**：记录双方的喜好、心愿清单
+- **安排计划**：支持两种方式
+  - 方式一：在纪念日详情页维护（添加礼物/餐厅/蛋糕/预算等安排项）
+  - 方式二：收到提醒时快速安排
+- **智能建议**：提醒时附带安排建议（餐厅推荐、活动策划等）
+- **礼物推荐**：结合个人喜好记录 + 联网搜索分析，推荐礼物选项，可一键加入老公购物清单
+- 主动关怀式提醒（低打扰原则）
+
+**M8 旅行/出行计划（衣食住行）**
+- **🚗 行**：去程/回程交通、当地交通、订票信息
+- **🏨 住**：酒店/民宿预订、入住时间、订单号
+- **🍜 食**：餐厅预订、想吃的本地美食、餐饮预算
+- **👕 衣/购物**：行李清单（打包进度）、购物计划（特产/纪念品）
+- **📋 行程总览**：按天展示行程安排
+- **💰 预算汇总**：各板块预算 + 总计
+- 旅行结束后一键汇总实际花费，自动归入M3
+
+**M9 家庭文件/证件管理提醒**
+- 身份证到期提醒、护照有效期提醒
+- 房产证、结婚证、户口本等重要证件信息记录
+- 到期前较长时间提醒（如提前3个月）
+- 可记录证件存放位置
+
+**M10 饮食/菜谱计划（简单版）**
+- 本周菜单规划
+- 冰箱食材保质期提醒
+- 想吃的菜/想做的菜记录
+- 定位：简单，不做复杂功能
+
+**M11 老婆化妆品备忘录**
+- **基础信息**：品牌/产品名、种类、色号/规格、产品照片
+- **购买信息**：购买价格（关联M3）、购买日期、购买渠道
+- **保质期管理**：生产日期、截止日期、开封日期、开封后保质期（6M/12M等）、到期提醒
+- **存量管理**：存量、剩余量状态（全新/一半/快用完）、使用频率
+- **体验记录**：回购意愿、存放位置
+- **过期预警 + 智能推荐**：
+  - 快过期：提醒"趁过期前多用用"
+  - 已过期：推荐相似替代品
+  - 联网搜索小红书、电商等平台评价
+  - AI综合分析评分、好评率、推荐理由
+  - **对话式追问**：用户可输入肤质/预算/需求等条件，重新推荐
+  - 多轮对话，直到满意
+  - 选中产品一键加入老婆购物清单
+- **快用完联动**：快用完的产品可一键添加到M2老婆购物清单
+
+**M12 工具/设备管理（老公专属）**
+- 电动工具、户外装备等物品管理
+- 记录存放位置、购买时间、保修期
+- 保修到期提醒
+
+**M13 账号/密码备忘（夫妻共用）**
+- 记录家庭相关账号信息（智能家居、WiFi、门锁、会员等）
+- 夫妻双方均可添加、修改、查阅
+- 定位：轻量备忘，不替代专业密码管理器
+
+### 4.3 非功能性需求
+
+- **响应时延**:文字交互端到端 < 2s(P95),语音交互 < 3s
+- **可靠性**:提醒到点推送成功率 ≥ 99.9%,不允许漏提醒
+- **隐私安全**:家庭数据默认仅家庭空间内可见,支持本地/云端加密存储
+- **可扩展性**:意图识别与执行模块解耦,便于后续接入更多设备端
+- **多端一致性**:同一家庭空间在不同设备上的数据强一致
+
+---
+
+## 5. 系统架构设计
+
+### 5.1 总体架构
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                        交互层 (多端)                        │
+│   手机 App │ 微信小程序 │ 智能音箱 │ 平板 Widget            │
+└───────────────────────┬─────────────────────────────────┘
+                         │  统一网关 (Gateway / API)
+┌───────────────────────▼─────────────────────────────────┐
+│                       智能体核心层                          │
+│  ┌───────────┐  ┌───────────┐  ┌───────────┐             │
+│  │ NLU/意图识别│→│ 对话管理器  │→│ 任务规划器   │             │
+│  └───────────┘  └───────────┘  └───────────┘             │
+│         │              │              │                   │
+│  ┌───────────────────────────────────────────┐            │
+│  │            记忆层 (短期上下文 + 长期记忆)      │            │
+│  └───────────────────────────────────────────┘            │
+└───────────────────────┬─────────────────────────────────┘
+                         │
+┌───────────────────────▼─────────────────────────────────┐
+│                       执行/服务层                          │
+│  备忘条目服务 │ 提醒调度服务 │ 成员角色服务 │ 通知推送服务    │
+└───────────────────────┬─────────────────────────────────┘
+                         │
+┌───────────────────────▼─────────────────────────────────┐
+│                        数据层                              │
+│   结构化数据库(备忘条目/成员) │ 向量存储(长期记忆检索)        │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 5.2 模块说明
+
+| 模块 | 职责 |
+|---|---|
+| 统一网关 | 鉴权、多端协议转换(文字/语音统一为文本流) |
+| NLU/意图识别 | 识别用户意图(创建/查询/修改/删除/闲聊)+ 槽位抽取(时间、人物、事项) |
+| 对话管理器 | 维护多轮对话状态,处理指代消解、澄清追问 |
+| 任务规划器 | 将意图转为具体动作序列(如"创建条目→设置提醒→通知负责人") |
+| 记忆层 | 短期:当前会话上下文;长期:夫妻二人偏好、历史习惯、重要日期 |
+| 提醒调度服务 | 基于时间轮/延迟队列管理海量定时任务,保证到点必达 |
+| 通知推送服务 | 对接 App Push、短信、音箱语音播报等多种通道 |
+
+---
+
+## 6. 智能体核心设计
+
+### 6.1 意图识别与槽位抽取
+
+采用"大模型 + 结构化输出"的方式,将自然语言解析为标准 JSON:
+
+```json
+{
+  "intent": "create_memo",
+  "slots": {
+    "content": "交电费",
+    "raw_time_expr": "下周三",
+    "resolved_time": "2026-09-02T10:00:00+08:00",
+    "assignee": "self",
+    "repeat": null,
+    "category": "financial"
+  },
+  "confidence": 0.92
+}
+```
+
+对于置信度较低或槽位缺失(如时间不明确)的情况,对话管理器发起澄清追问,而不是直接猜测执行。
+
+**意图体系与业务域(M1-M13)的映射**:
+
+| 业务域 | 扩展意图示例 | 典型联动动作 |
+|---|---|---|
+| M2 购物清单 | add_shopping_item / agree_item / comment_item | 标记已购买→自动写入M3收支 |
+| M3 收支 | record_expense / query_budget | 与M2/M4/M6/M7/M8自动归集 |
+| M4 车辆 | record_refuel / query_violation | 加油记录→更新current_mileage→里程达标触发保养提醒 |
+| M5 健康 | record_period / record_mood / log_bp | 异常趋势→建议就医并登记预约 |
+| M11 化妆品 | update_remaining / recommend_cosmetic | "粉底快用完了"→更新存量→一键加入M2老婆购物清单 |
+| M12 工具 | register_tool | 保修临期→创建memo_item提醒 |
+
+> 跨模块联动(如化妆品快用完→购物清单)是本产品的核心差异化能力,任务规划器需支持"意图→多模块动作序列"的编排。
+
+### 6.2 时间理解设计
+
+- 基础层:相对时间表达式解析(明天、下周三、月底)
+- 增强层:结合家庭"记忆"的个性化解析,例如"你下班后"→ 结合已知的下班时间(如 18:00)换算为具体时间
+- 兜底策略:无法确定时,始终以"确认候选时间 + 用户一键修改"的方式收尾,不做无提示的强猜测
+
+### 6.3 记忆管理
+
+| 类型 | 内容示例 | 存储方式 | 生命周期 |
+|---|---|---|---|
+| 短期记忆 | 当前多轮对话的上下文、上一条被引用的备忘条目 | 内存/会话缓存 | 会话级,超时清空 |
+| 长期记忆 | 夫妻关系、常用时间习惯、重要纪念日 | 结构化字段 + 向量库 | 持久化,用户可查看/删除 |
+| 事实性记忆 | 已创建的备忘条目本身 | 结构化数据库 | 按条目状态管理 |
+
+隐私原则:长期记忆的每一条都应可被用户在设置页查看、编辑、删除,不做"黑箱"记忆。
+
+### 6.4 多轮对话与指代消解
+
+维护一个"最近操作对象"指针(last_referenced_memo_id),当用户说"改成""删掉那条"时,优先解析为该指针指向的条目,若存在歧义(如最近有多条相关记录)则主动列出选项让用户选择,而不是随意猜测执行删除类操作。
+
+### 6.5 主动提醒/建议机制(P2)
+
+基于长期记忆中的重要日期(生日、纪念日)和历史行为模式(如"每月月初总是问水电费"),智能体可在恰当时机主动发起建议,但需遵循"低打扰"原则:
+
+- 主动建议仅通过非侵入式方式呈现(如 App 内消息卡片),不做强推送
+- 用户可一键关闭某类主动建议
+
+---
+
+## 7. 数据模型设计(完整共46表)
+
+> **通用约定**：除特殊说明外，所有表默认包含 `created_at`、`updated_at` 审计字段，下文表格中省略。
+
+### 7.1 核心基础表
+
+**user（用户账号）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| phone | string | 手机号（登录凭证） |
+| password_hash | string | 密码哈希 |
+| nickname | string | 昵称 |
+
+**family（家庭空间）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| name | string | 家庭名称 |
+| created_at | datetime | 创建时间 |
+
+**family_member（家庭成员）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| role | enum | 老公/老婆 |
+| nickname | string | 自定义昵称 |
+| user_id | string | 绑定的用户账号ID |
+| notify_channels | array | 通知渠道 |
+| quiet_hours | json | 免打扰时段设置 |
+
+### 7.1.1 智能体核心表（对话创建的备忘/提醒闭环）
+
+**memo_item（备忘条目）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| content | text | 提醒内容 |
+| category | string | 分类（financial/health/household等） |
+| assignee_id | string FK | 负责人（家庭成员） |
+| created_by | string FK | 创建人 |
+| status | enum | 待处理/已完成/已取消 |
+| source | enum | 对话创建/手动创建/系统生成 |
+| related_type | string | 关联业务模块类型（如 payment/cosmetic/document） |
+| related_id | string | 关联业务记录ID |
+
+**reminder_task（提醒任务）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| memo_id | string FK | 关联备忘条目（业务模块触发的提醒可空） |
+| remind_at | datetime | 提醒时间 |
+| repeat_rule | string | 重复规则（每天/每周/每月/自定义周期，可空） |
+| advance_days | int | 提前几天提醒 |
+| notify_channels | array | 通知渠道 |
+| status | enum | 待触发/已触发/已取消/已跳过 |
+| escalation_rule | json | 逾期升级策略（如逾期通知对方） |
+| last_triggered_at | datetime | 上次触发时间（逾期重推判断用） |
+
+**notification_record（通知发送记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| reminder_id | string FK | 关联提醒任务 |
+| member_id | string FK | 接收人 |
+| channel | enum | App推送/短信/语音播报 |
+| sent_at | datetime | 发送时间 |
+| status | enum | 成功/失败 |
+| failure_reason | string | 失败原因 |
+
+### 7.2 M1 周期性缴费
+
+**payment_item（缴费项目）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | enum | 水费/电费/燃气费/物业费 |
+| frequency | enum | 每月/每半年 |
+| reminder_day | int | 每月提醒日 |
+| advance_days | int | 提前几天提醒 |
+| estimated_amount | decimal | 预估金额 |
+| is_active | bool | 是否启用 |
+
+**payment_record（缴费记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| payment_item_id | string FK | 关联缴费项目 |
+| actual_amount | decimal | 实际金额 |
+| paid_date | date | 缴纳日期 |
+| status | enum | 已缴/未缴/逾期 |
+| income_expense_id | string FK | 关联M3收支记录 |
+
+### 7.3 M2 购物清单
+
+**shopping_item（购物清单物品）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| list_type | enum | 家用/老公个人/老婆个人 |
+| name | string | 物品名称 |
+| category | string | 分类 |
+| image | string | 图片URL |
+| estimated_price | decimal | 预估价格 |
+| purchase_reason | text | 购买理由 |
+| status | enum | 待购买/已购买/已取消 |
+| actual_price | decimal | 实际价格 |
+| purchase_method | string | 购买方式 |
+| purchase_date | date | 购买日期 |
+| created_by | string FK | 创建人 |
+| assignee | string FK | 负责人 |
+| income_expense_id | string FK | 关联M3收支记录 |
+
+**household_agreement（家用清单同意表）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| shopping_item_id | string FK | 关联物品 |
+| member_id | string FK | 家庭成员 |
+| agreement | bool | 同意/不同意 |
+| updated_at | datetime | 更新时间 |
+
+**shopping_comment（购物清单评论）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| shopping_item_id | string FK | 关联物品 |
+| from_member_id | string FK | 评论人 |
+| to_member_id | string FK | 回复对象 |
+| content | text | 评论内容 |
+| parent_id | string FK | 父评论ID |
+| created_at | datetime | 创建时间 |
+
+### 7.4 M3 家庭收支记录
+
+**income_expense（收支记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| type | enum | 支出/收入 |
+| amount | decimal | 金额 |
+| category | string | 分类 |
+| note | text | 备注 |
+| payer_id | string FK | 谁付的 |
+| record_date | date | 日期 |
+| source_type | string | 来源类型 |
+| source_id | string | 来源关联ID |
+
+### 7.5 M4 车辆管理
+
+**vehicle_info（车辆信息）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| brand | string | 品牌 |
+| model | string | 型号 |
+| plate_number | string | 车牌号 |
+| purchase_date | date | 购买日期 |
+| insurance_expire | date | 保险到期日 |
+| insurance_company | string | 保险公司 |
+| maintenance_shop | string | 4S店名称 |
+| maintenance_address | string | 4S店地址 |
+| maintenance_contact | string | 联系人 |
+| maintenance_phone | string | 联系电话 |
+| next_maintenance_date | date | 下次保养日期 |
+| next_maintenance_mileage | int | 下次保养里程 |
+| next_inspection_date | date | 下次年检日期 |
+| current_mileage | int | 当前总里程（加油/保养时更新，用于里程保养触发） |
+
+**vehicle_expense（用车支出）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| vehicle_id | string FK | 关联车辆 |
+| expense_type | enum | 加油/充电/保险/违章/保养/其他 |
+| amount | decimal | 金额 |
+| location | string | 地点 |
+| date | date | 日期 |
+| note | text | 备注 |
+| income_expense_id | string FK | 关联M3 |
+
+**driving_license_info（驾驶证信息）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 家庭成员 |
+| license_no | string | 驾驶证号 |
+| issue_date | date | 初次领证日期 |
+| expire_date | date | 有效期至 |
+| clear_cycle_date | date | 清分周期日期 |
+
+**violation_record（违章扣分记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 家庭成员 |
+| violation_date | date | 违章日期 |
+| location | string | 违章地点 |
+| reason | string | 违章原因 |
+| deduction | int | 扣分 |
+| fine | decimal | 罚款金额 |
+| remaining_points | int | 剩余分数 |
+| clear_date | date | 清零日期 |
+
+### 7.6 M5 家庭健康管理
+
+**health_profile（成员健康档案）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 家庭成员 |
+| phone | string | 手机号码 |
+| blood_type | string | 血型 |
+| allergy_drugs | text | 过敏药物 |
+| medical_history | text | 既往病史 |
+| updated_at | datetime | 更新时间 |
+
+**emergency_contact（紧急联系人）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| name | string | 姓名 |
+| relationship | string | 关系 |
+| phone | string | 联系电话 |
+
+**health_checkup（周期检查计划）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 家庭成员 |
+| checkup_type | enum | 体检/牙科/眼科/其他 |
+| last_date | date | 上次检查时间 |
+| next_date | date | 下次提醒时间 |
+| cycle_months | int | 检查周期（月） |
+| is_active | bool | 是否启用 |
+
+**health_appointment（预约登记）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 家庭成员 |
+| checkup_id | string FK | 关联检查计划（可空） |
+| hospital | string | 医院 |
+| address | string | 地址 |
+| appointment_time | datetime | 预约时间 |
+| note | text | 注意事项 |
+| status | enum | 待就诊/已完成/已取消 |
+
+**medical_record（病例/健康记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| record_type | enum | 病例/体检/手术/检查报告/疫苗/用药/中医/理疗/其他 |
+| title | string | 标题 |
+| hospital | string | 医院 |
+| doctor | string | 医生 |
+| record_date | date | 记录日期 |
+| note | text | 备注 |
+
+**medical_attachment（病历附件）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| medical_record_id | string FK | 关联病历记录 |
+| file_url | string | 文件地址（拍照上传） |
+| file_type | string | 文件类型（图片/PDF等） |
+| created_at | datetime | 创建时间 |
+
+**period_record（生理期记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| start_date | date | 开始日期 |
+| end_date | date | 结束日期 |
+| is_on_time | bool | 是否准时 |
+| symptoms | array | 症状（多选） |
+| painkiller_taken | bool | 是否已吃止疼药 |
+
+**mood_record（心理健康记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| mood | string | 表情/心情 |
+| note | text | 备注 |
+| record_date | date | 记录日期 |
+
+**health_metric（健康数据记录）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| metric_type | enum | 血压/体重/血糖/其他 |
+| value | string | 数值 |
+| unit | string | 单位 |
+| record_date | date | 记录日期 |
+
+**health_insurance（健康保险）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 被保险成员 |
+| insurance_type | enum | 医疗险/重疾险/意外险/其他 |
+| insured_amount | decimal | 保额 |
+| expire_date | date | 到期日 |
+| claim_phone | string | 理赔电话 |
+
+**hospital_doctor（常去医院/医生）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| hospital_name | string | 医院名称 |
+| department | string | 科室 |
+| doctor_name | string | 医生姓名 |
+| phone | string | 联系电话 |
+| address | string | 地址 |
+
+### 7.7 M6 社交/人情往来
+
+**social_event（人情往来）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | string | 事件名称 |
+| person_name | string | 对方姓名 |
+| relationship | string | 关系 |
+| event_type | enum | 婚礼/生日/满月/节日/聚会/其他 |
+| direction | enum | 送礼（支出）/收礼（收入），决定归入M3的收支方向 |
+| calendar_type | enum | 公历/农历 |
+| amount | decimal | 随礼金额 |
+| event_date | date | 事件日期 |
+| reminder_days | int | 提前几天提醒 |
+| status | enum | 待处理/已处理 |
+| note | text | 备注 |
+| income_expense_id | string FK | 关联M3 |
+
+### 7.8 M7 纪念日/重要日期
+
+**anniversary（纪念日）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | string | 名称 |
+| date | date | 日期 |
+| calendar_type | enum | 公历/农历（生日/纪念日多为农历，逐年换算后提醒） |
+| reminder_days | int | 提前几天提醒 |
+| is_active | bool | 是否启用 |
+
+**anniversary_plan（纪念日安排项）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| anniversary_id | string FK | 关联纪念日 |
+| plan_type | enum | 礼物/餐厅/蛋糕/活动/其他 |
+| content | string | 安排内容 |
+| status | enum | 待安排/已安排 |
+| amount | decimal | 预算金额 |
+| income_expense_id | string FK | 关联M3 |
+
+**wish_list（喜好愿望）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| member_id | string FK | 所属成员 |
+| content | string | 愿望内容 |
+| category | string | 分类 |
+| source | enum | 手动录入/系统推断 |
+| created_at | datetime | 创建时间 |
+
+### 7.9 M8 旅行/出行计划
+
+**travel_plan（行程）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| destination | string | 目的地 |
+| start_date | date | 出发日期 |
+| end_date | date | 返回日期 |
+| companions | string | 同行人 |
+| total_budget | decimal | 总预算 |
+| total_actual | decimal | 实际总花费 |
+| status | enum | 计划中/进行中/已完成 |
+
+**travel_transportation（交通）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| direction | enum | 去程/回程/当地 |
+| type | enum | 飞机/火车/汽车/租车/其他 |
+| provider | string | 航空公司/车次 |
+| detail | string | 班次号 |
+| departure | string | 出发地 |
+| arrival | string | 到达地 |
+| departure_time | datetime | 出发时间 |
+| arrival_time | datetime | 到达时间 |
+| amount | decimal | 费用 |
+| status | enum | 待预订/已预订 |
+| income_expense_id | string FK | 关联M3 |
+
+**travel_accommodation（住宿）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| name | string | 酒店名称 |
+| check_in | date | 入住日期 |
+| check_out | date | 退房日期 |
+| nights | int | 住几晚 |
+| order_no | string | 订单号 |
+| amount | decimal | 费用 |
+| status | enum | 待预订/已确认 |
+| income_expense_id | string FK | 关联M3 |
+
+**travel_dining（餐饮）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| name | string | 餐厅名称 |
+| date | date | 用餐日期 |
+| meal | enum | 早餐/午餐/晚餐 |
+| amount | decimal | 预算金额 |
+| status | enum | 想吃/待预订/已预订 |
+| note | text | 备注 |
+
+**travel_luggage（行李清单）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| item_name | string | 物品名称 |
+| category | enum | 衣物/日用品/电子/证件/药品/其他 |
+| is_packed | bool | 是否已打包 |
+
+**travel_shopping_plan（购物计划）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| item | string | 想买的物品 |
+| estimated_price | decimal | 预估价格 |
+| is_bought | bool | 是否已购买 |
+
+**travel_itinerary（日程安排）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| travel_id | string FK | 关联行程 |
+| date | date | 日期 |
+| time | time | 时间 |
+| activity | string | 活动内容 |
+| note | text | 备注 |
+
+### 7.10 M9 证件管理
+
+**document（证件）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | enum | 身份证/护照/房产证/结婚证/户口本/其他 |
+| owner_id | string FK | 持有人 |
+| doc_number | string | 证件号码 |
+| issue_date | date | 签发日期 |
+| expire_date | date | 到期日期 |
+| location | string | 存放位置 |
+| reminder_days | int | 提前多少天提醒 |
+| note | text | 备注 |
+
+### 7.11 M10 饮食/菜谱计划
+
+**meal_plan（饮食计划）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| dish_name | string | 菜名 |
+| plan_date | date | 计划日期 |
+| status | enum | 想吃/已安排/已做 |
+| created_by | string FK | 创建人 |
+
+**ingredient（食材）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | string | 食材名称 |
+| quantity | string | 数量 |
+| expire_date | date | 保质期到期日 |
+| storage | string | 存放位置 |
+
+### 7.12 M11 化妆品备忘录
+
+**cosmetic（化妆品）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| member_id | string FK | 持有人（老婆） |
+| brand | string | 品牌 |
+| product_name | string | 产品名 |
+| category | string | 种类 |
+| color_spec | string | 色号/规格 |
+| image | string | 产品照片 |
+| purchase_price | decimal | 购买价格 |
+| purchase_channel | string | 购买渠道 |
+| purchase_date | date | 购买日期 |
+| produce_date | date | 生产日期 |
+| expire_date | date | 截止日期 |
+| open_date | date | 开封日期 |
+| shelf_life_after_open | int | 开封后保质期(月) |
+| remaining | enum | 全新/1/4/一半/3/4/快用完/已用完 |
+| frequency | enum | 每天用/偶尔用/闲置/特定场合 |
+| location | string | 存放位置 |
+| repurchase_intent | enum | 回购/一般/不回购 |
+| status | enum | 正常/即将过期/已过期/已用完 |
+
+### 7.13 M12 工具/设备管理
+
+**tool_equipment（工具设备）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | string | 工具名称 |
+| category | string | 分类 |
+| location | string | 存放位置 |
+| purchase_date | date | 购买日期 |
+| warranty_date | date | 保修到期日 |
+| note | text | 备注 |
+
+### 7.14 M13 账号/密码备忘
+
+**account_memo（账号密码）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| name | string | 账号名称 |
+| account | string | 账号名 |
+| password | string | 密码（AES加密存储，密钥由用户主密码派生） |
+| url | string | 登录地址 |
+| note | text | 备注 |
+| created_by | string FK | 创建人 |
+| updated_by | string FK | 最后修改人 |
+
+### 7.15 支撑表（首页与通用能力）
+
+**monthly_budget（月度预算）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| month | string | 月份（yyyy-MM） |
+| category | string | 分类（空表示总预算） |
+| budget_amount | decimal | 预算金额 |
+
+**activity_log（操作动态）**
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | string PK | 主键 |
+| family_id | string FK | 所属家庭 |
+| member_id | string FK | 操作人（系统提醒时为空） |
+| action_type | enum | 购买/评论/创建/修改/分配/系统提醒 |
+| target_type | string | 目标对象类型（shopping_item/cosmetic等） |
+| target_id | string | 目标对象ID |
+| summary | string | 动态摘要（供首页时间流展示） |
+| created_at | datetime | 创建时间 |
+
+> 首页"关注动态"时间流与"本月收支超支比例"卡片分别由 activity_log、monthly_budget 支撑。
+
+---
+
+## 8. 交互设计要点
+
+- **文字端**:对话式卡片交互,创建/修改后以结构化卡片形式复述确认("已为你创建:9月2日 10:00 交电费"),用户可直接在卡片上编辑
+- **语音端**(音箱场景):精简确认语句,避免长句朗读;支持"打断式"修改
+- **权限提示**:被分配任务后需明确告知"由谁分配、何时分配",避免夫妻之间的信息不透明
+
+### 8.1 首页布局（A+C融合方案）
+
+页面从上到下结构：
+
+**① 顶部导航**
+- 搜索框 + 当前角色标识（老公/老婆）
+
+**② 今日待办**
+- 按紧急程度排列：逾期事项置顶（红色）→ 今天待办（黄色）→ 近期事项（绿色）
+- 每项显示提醒时间、内容、负责人
+
+**③ 关注动态（时间流）**
+- 双方最新操作（老婆买了什么、评论了什么）
+- 系统智能提醒（保险到期、化妆品过期预警等）
+- 对方的提醒/分配事项
+- 排序逻辑：紧急提醒置顶 → 最新操作 → 系统提醒 → 对方分配
+
+**④ 本月收支**
+- 预算卡片，显示本月总支出、超支比例
+- 点击进入详情
+
+**⑤ 快捷入口**
+- 记一笔、购物单、车辆、健康、化妆品等图标入口
+
+**⑥ 底部Tab导航**
+- 首页 / 购物 / 健康 / 车辆 / 我的
+- 其余模块（纪念日/人情/旅行/证件/菜谱/化妆品/工具/账号密码）通过首页快捷入口和"我的"页面二级导航进入，避免 Tab 超载
+
+**角色差异化：**
+- 老公视角：待办偏缴费/车辆提醒，动态流偏车辆/工具相关
+- 老婆视角：待办偏化妆品过期/生理期提醒，动态流偏化妆品/健康相关
+
+---
+
+## 9. 技术选型建议
+
+| 层级 | 选型建议 | 说明 |
+|---|---|---|
+| NLU/对话 | 大语言模型(结构化输出/Function Calling) | 处理意图识别、槽位抽取、多轮对话 |
+| 时间解析 | 规则引擎 + 大模型辅助兜底 | 常见相对时间用规则保证稳定性,长尾表达用模型 |
+| 提醒调度 | 单机持久化延迟队列（数据库任务表 + 定时扫描 + 补偿重试） | 二人规模无需分布式时间轮；任务持久化保证重启不丢，预留多副本扩展 |
+| 数据存储 | 关系型数据库(条目/成员)；向量检索初期可选 | 长期记忆初期用结构化字段即可，主动建议等语义检索需求上线后再引入向量库 |
+| 推送 | App Push + 短信网关 + 音箱 TTS | 多通道保证到达率 |
+| 客户端 | 移动 App / 小程序 / 智能音箱 SDK | 统一走网关协议 |
+
+---
+
+## 10. 安全与隐私设计
+
+1. **数据隔离**:每个夫妻空间之间数据严格隔离,两人均可查看所有内容(当前不设细粒度权限)
+2. **敏感信息最小化**:不主动记录与提醒无关的敏感信息(如聊天中偶然提及的健康隐私),仅记录用户明确要求记忆的内容
+3. **记忆可控**:提供"记忆管理"页面,用户可查看/删除任意一条长期记忆
+4. **数据加密**:传输层 TLS,存储层敏感字段加密
+5. **高敏数据默认私密**:生理期记录(period_record)、心理健康(mood_record)默认仅本人可见,需显式授权后才对配偶开放,不适用"家庭空间内均可见"的默认规则
+6. **联网搜索外发最小化**:化妆品/礼物推荐的联网搜索仅外发品类、预算等必要条件,不上传家庭内部数据
+
+---
+
+## 11. 迭代计划(建议)
+
+> 已按 4.2 的 M1-M13 业务模块重新排期，每阶段保持可独立交付的闭环。
+
+| 阶段 | 目标 | 核心内容 |
+|---|---|---|
+| MVP | 跑通智能体核心闭环 | 账号/家庭空间绑定、对话创建/查询/修改备忘提醒（user/memo_item/reminder_task/notification_record）、基础推送、首页今日待办 |
+| V1.0 | 基础业务模块 | M3 收支 + M1 缴费 + M2 购物清单（含夫妻协商）、月度预算、首页动态流 |
+| V1.1 | 重点垂直模块 | M5 健康管理（重点功能）、M4 车辆管理 |
+| V1.2 | 生活扩展模块 | M7 纪念日、M6 人情往来、M11 化妆品（含智能推荐） |
+| V1.3 | 长尾模块 | M8 旅行、M9 证件、M10 菜谱、M12 工具、M13 账号密码 |
+| V2.0 | 智能化与生态 | 语音接入（音箱/TTS）、模糊时间个性化解析、主动建议、跨模块联动增强、第三方日历同步 |
+
+---
+
+## 12. 风险与应对
+
+| 风险 | 影响 | 应对措施 |
+|---|---|---|
+| 时间理解歧义导致漏提醒/错提醒 | 高 | 低置信度时强制澄清确认,不做静默猜测 |
+| 多设备数据不一致 | 中 | 采用统一后端 + 强一致写入,客户端做增量同步 |
+| 夫妻间隐私边界模糊(如互相监督被反感) | 中 | 明确分配任务可追溯来源,支持个人隐私提醒模式 |
+| 提醒调度服务单点故障 | 高 | 调度服务多副本 + 持久化任务队列,避免内存态丢失 |
+
+---
+
+## 13. 待评审问题
+
+1. 夫妻空间的绑定方式:是邀请码绑定,还是同一账号下的子账号?
+2. 主动建议功能的打扰边界,是否需要"免打扰时段"设置(如晚上10点后不推送)?
+3. 当前仅支持夫妻二人,未来是否需要扩展到更多家庭成员(如孩子、老人)?
+
+> 注:原"语音识别是否要求端侧离线能力"问题已有结论(见 1.3 非目标:第一期不做端侧离线 ASR),已移除。


### PR DESCRIPTION
## What Changed
新增家用备忘录智能体完整项目（`家用备忘录智能体/` 目录）：

- **设计文档 v1.1**：业务模块统一编号 M1-M13，补齐 M5 健康管理等完整数据模型（46 表）、智能体核心表（memo_item / reminder_task / notification_record 等）、迭代计划重排
- **FastAPI 后端**：微信登录、邀请码绑定家庭空间、NLU 自然语言理解、提醒调度，以及缴费/购物/收支/车辆/纪念日等模块 API
- **微信小程序前端**：对话式创建提醒、购物清单、收支统计等页面
- **部署配置**：Dockerfile、docker-compose.yml、alembic 迁移、.env.example

## Why
为夫妻二人场景提供自然语言驱动的家庭备忘录/提醒服务，此为 MVP 阶段完整交付。

## Impact
- 纯新增目录，不影响仓库现有代码
- .gitignore 已排除 .env 等敏感文件，无凭据入库

## Validation
- 数据模型与设计文档 v1.1 的表定义逐一对齐
- 后端依赖清单与 alembic 迁移结构完整可初始化