### PR TITLE
feat(来源溯源): 增加报告主张级来源引用

### DIFF
--- a/ForumEngine/monitor.py
+++ b/ForumEngine/monitor.py
@@ -9,9 +9,42 @@ from pathlib import Path
 from datetime import datetime
 import re
 import json
-from typing import Dict, Optional, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, List
 from threading import Lock
 from loguru import logger
+
+
+@dataclass
+class ForumMessage:
+    """Structured forum message; its text is context, never evidence itself."""
+
+    content: str = ""
+    source: str = ""
+    timestamp: str = ""
+    referenced_evidence_ids: List[str] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "content": self.content,
+            "source": self.source,
+            "timestamp": self.timestamp,
+            "referenced_evidence_ids": list(self.referenced_evidence_ids),
+            "meta": dict(self.meta),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ForumMessage":
+        data = data or {}
+        refs = data.get("referenced_evidence_ids") or []
+        return cls(
+            content=str(data.get("content") or ""),
+            source=str(data.get("source") or ""),
+            timestamp=str(data.get("timestamp") or ""),
+            referenced_evidence_ids=[str(item) for item in refs if item],
+            meta=dict(data.get("meta") or {}),
+        )
 
 # 导入论坛主持人模块
 try:
@@ -103,7 +136,12 @@ class LogMonitor:
         except Exception as e:
             logger.exception(f"ForumEngine: 清空forum.log失败: {e}")
    
-    def write_to_forum_log(self, content: str, source: str = None):
+    def write_to_forum_log(
+        self,
+        content: str,
+        source: str = None,
+        referenced_evidence_ids: Optional[List[str]] = None,
+    ):
         """写入内容到forum.log（线程安全）"""
         try:
             with self.write_lock:  # 使用锁确保线程安全
@@ -111,9 +149,13 @@ class LogMonitor:
                     timestamp = datetime.now().strftime('%H:%M:%S')
                     # 将内容中的实际换行符转换为\n字符串，确保整个记录在一行
                     content_one_line = content.replace('\n', '\\n').replace('\r', '\\r')
+                    evidence_prefix = ""
+                    if referenced_evidence_ids:
+                        refs = list(dict.fromkeys(str(item) for item in referenced_evidence_ids if item))
+                        evidence_prefix = f"[EVIDENCE_IDS:{json.dumps(refs, ensure_ascii=False)}] "
                     # 如果提供了来源标签，则在时间戳后添加
                     if source:
-                        f.write(f"[{timestamp}] [{source}] {content_one_line}\n")
+                        f.write(f"[{timestamp}] [{source}] {evidence_prefix}{content_one_line}\n")
                     else:
                         f.write(f"[{timestamp}] {content_one_line}\n")
                     f.flush()

--- a/InsightEngine/agent.py
+++ b/InsightEngine/agent.py
@@ -33,6 +33,15 @@ from .tools import (
 from .utils import format_search_results_for_prompt
 from .utils.config import Settings, settings
 
+from common.provenance.io import save_sidecar
+from common.provenance.models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord
+from common.provenance.normalizer import (
+    add_search_results_to_bundle,
+    content_hash,
+    dedupe_bundle,
+    stable_id,
+)
+
 ENABLE_CLUSTERING: bool = True  # 是否启用聚类采样
 MAX_CLUSTERED_RESULTS: int = 50  # 聚类后最大返回结果数
 RESULTS_PER_CLUSTER: int = 5  # 每个聚类返回的结果数
@@ -91,6 +100,119 @@ class DeepSearchAgent:
         self.first_summary_node = FirstSummaryNode(self.llm_client)
         self.reflection_summary_node = ReflectionSummaryNode(self.llm_client)
         self.report_formatting_node = ReportFormattingNode(self.llm_client)
+
+    def _capture_internal_provenance(
+        self,
+        response: DBResponse,
+        search_results: List[Dict[str, Any]],
+        search_query: str,
+        paragraph_title: str,
+    ) -> int:
+        """Persist only database rows with complete, auditable lineage."""
+        if not response or not response.query_time:
+            return 0
+
+        filters = dict(response.parameters or {})
+        time_window = dict(response.time_window or {"kind": "unbounded"})
+        sample_size = int(response.results_count or 0)
+        aggregation_method = response.aggregation_method or "record_lookup"
+        valid_results = []
+        for result in search_results:
+            table = str(result.get("source_table") or "")
+            record_id = str(result.get("record_id") or "")
+            if not table or not record_id or sample_size <= 0:
+                continue
+            item = dict(result)
+            item.update(
+                {
+                    "source_type": "database",
+                    "evidence_type": "db_row",
+                    "table": table,
+                    "primary_key": record_id,
+                    "record_id": record_id,
+                    "query_time": response.query_time,
+                    "filters": filters,
+                    "time_window": time_window,
+                    "sample_size": sample_size,
+                    "aggregation_method": aggregation_method,
+                    "locator": {"table": table, "primary_key": record_id},
+                    "scope": {
+                        "subject": paragraph_title,
+                        "query": search_query,
+                        "query_time": response.query_time,
+                        "table": table,
+                        "filters": filters,
+                        "time_window": time_window,
+                        "sample_size": sample_size,
+                        "aggregation_method": aggregation_method,
+                        "row_ids": [record_id],
+                        "primary_key": record_id,
+                    },
+                }
+            )
+            valid_results.append(item)
+
+        self.state.provenance_bundle = add_search_results_to_bundle(
+            self.state.provenance_bundle,
+            agent="insight_engine",
+            results=valid_results,
+            query=search_query,
+            paragraph_title=paragraph_title,
+            source_type="database",
+            evidence_type="db_row",
+        )
+
+        if valid_results and aggregation_method != "record_lookup":
+            tables = sorted(set(response.tables or [item["source_table"] for item in valid_results]))
+            locator = {"table": tables, "query_time": response.query_time}
+            source_id = stable_id("src", "insight_engine", "db_agg", locator)
+            source = SourceRecord(
+                source_id=source_id,
+                agent="insight_engine",
+                source_type="database",
+                title="内部数据库聚合查询",
+                platform="internal_db",
+                retrieved_time=response.query_time,
+                locator=locator,
+                meta={"tables": tables},
+            )
+            scope = {
+                "subject": paragraph_title,
+                "query": search_query,
+                "query_time": response.query_time,
+                "table": tables,
+                "metric": "hotness_score",
+                "filters": filters,
+                "time_window": time_window,
+                "sample_size": sample_size,
+                "aggregation_method": aggregation_method,
+                "row_ids": [item["record_id"] for item in valid_results],
+            }
+            snippet = f"内部数据按 {aggregation_method} 聚合，共 {sample_size} 条记录。"
+            evidence = EvidenceRecord(
+                evidence_id=stable_id("ev", source_id, "db_agg", scope),
+                source_id=source_id,
+                agent="insight_engine",
+                evidence_type="db_agg",
+                snippet=snippet,
+                normalized_value={"sample_size": sample_size},
+                scope=scope,
+                meta={"content_hash": content_hash(snippet)},
+            )
+            claim = ClaimRecord(
+                claim_id=stable_id("claim", evidence.evidence_id, snippet),
+                text=snippet,
+                claim_type="metric",
+                evidence_ids=[evidence.evidence_id],
+                support_level="supported",
+                status="supported",
+                scope=scope,
+                meta={"candidate": True, "derived_from": "database_aggregation"},
+            )
+            self.state.provenance_bundle.add_records([source], [evidence], [claim])
+            self.state.provenance_bundle = dedupe_bundle(self.state.provenance_bundle)
+
+        return len(valid_results)
 
     def _get_clustering_model(self):
         """懒加载聚类模型"""
@@ -524,6 +646,12 @@ class DeepSearchAgent:
         logger.info(f"开始深度研究: {query}")
         logger.info(f"{'=' * 60}")
 
+        self.state.provenance_bundle = ProvenanceBundle(
+            agent="insight_engine",
+            bundle_id=stable_id("bundle", "insight_engine", query, datetime.now().isoformat()),
+            meta={"query": query},
+        )
+
         try:
             # Step 1: 生成报告结构
             self._generate_report_structure(query)
@@ -696,6 +824,8 @@ class DeepSearchAgent:
                         "content_type": result.content_type,
                         "author": result.author_nickname,
                         "engagement": result.engagement,
+                        "source_table": result.source_table,
+                        "record_id": result.record_id,
                     }
                 )
 
@@ -714,6 +844,13 @@ class DeepSearchAgent:
 
         # 更新状态中的搜索历史
         paragraph.research.add_search_results(search_query, search_results)
+        captured = self._capture_internal_provenance(
+            search_response, search_results, search_query, paragraph.title
+        )
+        if captured == 0:
+            paragraph.research.latest_summary = "未检索到可追溯内部证据"
+            logger.warning("  - 本轮结果缺少可追溯内部证据，跳过事实性总结")
+            return
 
         # 生成初始总结
         logger.info("  - 生成初始总结...")
@@ -858,6 +995,8 @@ class DeepSearchAgent:
                             "content_type": result.content_type,
                             "author": result.author_nickname,
                             "engagement": result.engagement,
+                            "source_table": result.source_table,
+                            "record_id": result.record_id,
                         }
                     )
 
@@ -876,6 +1015,12 @@ class DeepSearchAgent:
 
             # 更新搜索历史
             paragraph.research.add_search_results(search_query, search_results)
+            captured = self._capture_internal_provenance(
+                search_response, search_results, search_query, paragraph.title
+            )
+            if captured == 0:
+                logger.warning("    本轮结果缺少可追溯内部证据，跳过事实性总结")
+                continue
 
             # 生成反思总结
             reflection_summary_input = {
@@ -898,6 +1043,13 @@ class DeepSearchAgent:
     def _generate_final_report(self) -> str:
         """生成最终报告"""
         logger.info(f"\n[步骤 3] 生成最终报告...")
+
+        if not self.state.provenance_bundle.evidence:
+            final_report = "# 内部数据洞察\n\n未检索到可追溯内部证据"
+            self.state.final_report = final_report
+            self.state.mark_completed()
+            logger.warning("InsightEngine 未产生有效内部证据，已阻断事实性报告")
+            return final_report
 
         # 准备报告数据
         report_data = []
@@ -941,7 +1093,10 @@ class DeepSearchAgent:
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(report_content)
 
+        sidecar = save_sidecar(self.state.provenance_bundle, filepath)
+
         logger.info(f"报告已保存到: {filepath}")
+        logger.info(f"证据审计文件已保存到: {sidecar}")
 
         # 保存状态（如果配置允许）
         if self.config.SAVE_INTERMEDIATE_STATES:

--- a/InsightEngine/state/state.py
+++ b/InsightEngine/state/state.py
@@ -8,6 +8,8 @@ from typing import List, Dict, Any, Optional
 import json
 from datetime import datetime
 
+from common.provenance.models import ProvenanceBundle
+
 
 @dataclass
 class Search:
@@ -16,6 +18,13 @@ class Search:
     url: str = ""                      # 搜索结果的链接
     title: str = ""                    # 搜索结果标题
     content: str = ""                  # 搜索返回的内容
+    source_table: str = ""             # 内部数据表
+    record_id: str = ""                # 行级稳定定位
+    query_time: str = ""               # 本次查询时间
+    filters: Dict[str, Any] = field(default_factory=dict)
+    time_window: Dict[str, Any] = field(default_factory=dict)
+    sample_size: int = 0
+    aggregation_method: str = ""
     score: Optional[float] = None      # 相关度评分
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     
@@ -26,6 +35,13 @@ class Search:
             "url": self.url,
             "title": self.title,
             "content": self.content,
+            "source_table": self.source_table,
+            "record_id": self.record_id,
+            "query_time": self.query_time,
+            "filters": self.filters,
+            "time_window": self.time_window,
+            "sample_size": self.sample_size,
+            "aggregation_method": self.aggregation_method,
             "score": self.score,
             "timestamp": self.timestamp
         }
@@ -38,6 +54,13 @@ class Search:
             url=data.get("url", ""),
             title=data.get("title", ""),
             content=data.get("content", ""),
+            source_table=data.get("source_table", ""),
+            record_id=str(data.get("record_id", data.get("primary_key", "")) or ""),
+            query_time=data.get("query_time", ""),
+            filters=data.get("filters", {}) or {},
+            time_window=data.get("time_window", {}) or {},
+            sample_size=int(data.get("sample_size", 0) or 0),
+            aggregation_method=data.get("aggregation_method", ""),
             score=data.get("score"),
             timestamp=data.get("timestamp", datetime.now().isoformat())
         )
@@ -63,6 +86,13 @@ class Research:
                 url=result.get("url", ""),
                 title=result.get("title", ""),
                 content=result.get("content", ""),
+                source_table=result.get("source_table", ""),
+                record_id=str(result.get("record_id", result.get("primary_key", "")) or ""),
+                query_time=result.get("query_time", ""),
+                filters=result.get("filters", {}) or {},
+                time_window=result.get("time_window", {}) or {},
+                sample_size=int(result.get("sample_size", 0) or 0),
+                aggregation_method=result.get("aggregation_method", ""),
                 score=result.get("score")
             )
             self.add_search(search)
@@ -146,6 +176,7 @@ class State:
     report_title: str = ""                                         # 报告标题
     paragraphs: List[Paragraph] = field(default_factory=list)     # 段落列表
     final_report: str = ""                                         # 最终报告内容
+    provenance_bundle: ProvenanceBundle = field(default_factory=lambda: ProvenanceBundle(agent="insight_engine"))
     is_completed: bool = False                                     # 是否完成
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
@@ -215,6 +246,7 @@ class State:
             "report_title": self.report_title,
             "paragraphs": [p.to_dict() for p in self.paragraphs],
             "final_report": self.final_report,
+            "provenance_bundle": self.provenance_bundle.to_dict(),
             "is_completed": self.is_completed,
             "created_at": self.created_at,
             "updated_at": self.updated_at
@@ -234,6 +266,7 @@ class State:
             report_title=data.get("report_title", ""),
             paragraphs=paragraphs,
             final_report=data.get("final_report", ""),
+            provenance_bundle=ProvenanceBundle.from_dict(data.get("provenance_bundle")),
             is_completed=data.get("is_completed", False),
             created_at=data.get("created_at", datetime.now().isoformat()),
             updated_at=data.get("updated_at", datetime.now().isoformat())

--- a/InsightEngine/tools/search.py
+++ b/InsightEngine/tools/search.py
@@ -25,6 +25,7 @@ V3.0 核心更新:
 
 import os
 import json
+import copy
 from loguru import logger
 import asyncio
 from typing import List, Dict, Any, Optional, Literal
@@ -48,6 +49,8 @@ class QueryResult:
     source_keyword: Optional[str] = None
     hotness_score: float = 0.0
     source_table: str = ""
+    record_id: str = ""
+    provenance: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass
 class DBResponse:
@@ -57,6 +60,23 @@ class DBResponse:
     results: List[QueryResult] = field(default_factory=list)
     results_count: int = 0
     error_message: Optional[str] = None
+    query_time: str = field(default_factory=lambda: datetime.now().isoformat())
+    time_window: Dict[str, Any] = field(default_factory=dict)
+    tables: List[str] = field(default_factory=list)
+    aggregation_method: str = "record_lookup"
+
+    def __post_init__(self):
+        # Attach lineage before keyword expansion, deduplication or sampling can discard it.
+        if not self.query_time or not self.time_window or not self.aggregation_method:
+            return
+        for row in self.results:
+            if not row.provenance and row.source_table and row.record_id:
+                row.provenance = {
+                    "query_time": self.query_time, "table": row.source_table,
+                    "filters": copy.deepcopy(self.parameters), "time_window": dict(self.time_window),
+                    "sample_size": len(self.results), "aggregation_method": self.aggregation_method,
+                    "row_ids": [row.record_id], "primary_key": row.record_id,
+                }
 
 # --- 2. 核心客户端与专用工具集 ---
 
@@ -167,7 +187,7 @@ class MediaCrawlerDB:
             else: time_filter_sql, time_filter_param = "`create_time` >= %s", str(int(start_time.timestamp()))
 
             content_type = 'note' if table in ['weibo_note', 'xhs_note'] else 'content' if table == 'zhihu_content' else 'video'
-            query_template = "SELECT '{platform}' as p, '{type}' as t, {title} as title, {author} as author, {url} as url, {ts} as ts, {formula} as hotness_score, source_keyword, '{tbl}' as tbl FROM `{tbl}` WHERE {time_filter}"
+            query_template = "SELECT id as record_id, '{platform}' as p, '{type}' as t, {title} as title, {author} as author, {url} as url, {ts} as ts, {formula} as hotness_score, source_keyword, '{tbl}' as tbl FROM `{tbl}` WHERE {time_filter}"
             
             field_subs = {'platform': table.split('_')[0], 'type': content_type, 'title': 'title', 'author': 'nickname', 'url': 'video_url', 'ts': 'create_time', 'formula': formula, 'tbl': table, 'time_filter': time_filter_sql}
             if table == 'weibo_note': field_subs.update({'title': 'content', 'url': 'note_url', 'ts': 'create_date_time'})
@@ -181,14 +201,35 @@ class MediaCrawlerDB:
         final_query = f"({' ) UNION ALL ( '.join(all_queries)}) ORDER BY hotness_score DESC LIMIT %s"
         raw_results = self._execute_query(final_query, tuple(params) + (limit,))
 
-        formatted_results = [QueryResult(platform=r['p'], content_type=r['t'], title_or_content=r['title'], author_nickname=r.get('author'), url=r['url'], publish_time=self._to_datetime(r['ts']), engagement=self._extract_engagement(r), hotness_score=r.get('hotness_score', 0.0), source_keyword=r.get('source_keyword'), source_table=r['tbl']) for r in raw_results]
-        return DBResponse("search_hot_content", params_for_log, results=formatted_results, results_count=len(formatted_results))    
+        formatted_results = [QueryResult(platform=r['p'], content_type=r['t'], title_or_content=r['title'], author_nickname=r.get('author'), url=r['url'], publish_time=self._to_datetime(r['ts']), engagement=self._extract_engagement(r), hotness_score=r.get('hotness_score', 0.0), source_keyword=r.get('source_keyword'), source_table=r['tbl'], record_id=str(r.get('record_id') or '')) for r in raw_results]
+        return DBResponse(
+            "search_hot_content",
+            params_for_log,
+            results=formatted_results,
+            results_count=len(formatted_results),
+            time_window={"start": start_time.isoformat(), "end": now.isoformat()},
+            tables=list(hotness_formulas),
+            aggregation_method="weighted_engagement_rank",
+        )
 
     def _wrap_query_field_with_dialect(self, field: str) -> str:
         """根据数据库方言包装SQL查询"""
         if settings.DB_DIALECT == 'postgresql':
             return f'"{field}"'
         return f'`{field}`'
+
+    def _date_predicate(self, config, start_dt, end_dt):
+        field = self._wrap_query_field_with_dialect(config['time_col'])
+        kind = config['time_type']
+        if kind in {'sec', 'sec_str', 'ms'}:
+            multiplier = 1000 if kind == 'ms' else 1
+            bounds = (int(start_dt.timestamp() * multiplier), int(end_dt.timestamp() * multiplier))
+            if kind == 'sec_str':
+                cast_type = 'BIGINT' if settings.DB_DIALECT == 'postgresql' else 'SIGNED'
+                field = f'CAST({field} AS {cast_type})'
+        else:
+            bounds = (start_dt.strftime('%Y-%m-%d'), end_dt.strftime('%Y-%m-%d'))
+        return f'{field} >= :window_start AND {field} < :window_end', {'window_start': bounds[0], 'window_end': bounds[1]}
 
     def search_topic_globally(self, topic: str, limit_per_table: int = 100) -> DBResponse:
         """
@@ -229,9 +270,10 @@ class MediaCrawlerDB:
                     publish_time=self._to_datetime(time_key),
                     engagement=self._extract_engagement(row),
                     source_keyword=row.get('source_keyword'),
-                    source_table=table
+                    source_table=table,
+                    record_id=str(row.get('id') or '')
                 ))
-        return DBResponse("search_topic_globally", params_for_log, results=all_results, results_count=len(all_results))
+        return DBResponse("search_topic_globally", params_for_log, results=all_results, results_count=len(all_results), tables=list(search_configs), time_window={"kind": "unbounded"}, aggregation_method="record_lookup")
 
     def search_topic_by_date(self, topic: str, start_date: str, end_date: str, limit_per_table: int = 100) -> DBResponse:
         """
@@ -271,7 +313,9 @@ class MediaCrawlerDB:
                 param_dict[pname] = search_term
             param_dict['limit'] = limit_per_table
             where_clause = ' OR '.join(where_clauses)
-            query = f'SELECT * FROM {self._wrap_query_field_with_dialect(table)} WHERE {where_clause} ORDER BY id DESC LIMIT :limit'
+            time_clause, time_params = self._date_predicate(config, start_dt, end_dt)
+            param_dict.update(time_params)
+            query = f'SELECT * FROM {self._wrap_query_field_with_dialect(table)} WHERE ({where_clause}) AND ({time_clause}) ORDER BY id DESC LIMIT :limit'
             raw_results = self._execute_query(query, param_dict)
             for row in raw_results:
                 content = (row.get('title') or row.get('content') or row.get('desc') or row.get('content_text', ''))
@@ -284,9 +328,18 @@ class MediaCrawlerDB:
                     publish_time=self._to_datetime(time_key),
                     engagement=self._extract_engagement(row),
                     source_keyword=row.get('source_keyword'),
-                    source_table=table
+                    source_table=table,
+                    record_id=str(row.get('id') or '')
                 ))
-        return DBResponse("search_topic_by_date", params_for_log, results=all_results, results_count=len(all_results))
+        return DBResponse(
+            "search_topic_by_date",
+            params_for_log,
+            results=all_results,
+            results_count=len(all_results),
+            time_window={"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+            tables=list(search_configs),
+            aggregation_method="record_lookup",
+        )
         
     def get_comments_for_topic(self, topic: str, limit: int = 500) -> DBResponse:
         """
@@ -313,7 +366,7 @@ class MediaCrawlerDB:
             time_col = 'publish_time' if 'publish_time' in cols else 'create_date_time' if 'create_date_time' in cols else 'create_time'
             like_select = f"`{like_col}` as likes" if like_col else "'0' as likes"
             
-            query = (f"SELECT '{table.split('_')[0]}' as platform, `content`, `{author_col}` as author, "
+            query = (f"SELECT `id` as record_id, '{table.split('_')[0]}' as platform, `content`, `{author_col}` as author, "
                      f"`{time_col}` as ts, {like_select}, '{table}' as source_table "
                      f"FROM `{table}` WHERE `content` LIKE %s")
             all_queries.append(query)
@@ -322,8 +375,8 @@ class MediaCrawlerDB:
         params = (search_term,) * len(comment_tables) + (limit,)
         raw_results = self._execute_query(final_query, params)
         
-        formatted = [QueryResult(platform=r['platform'], content_type='comment', title_or_content=r['content'], author_nickname=r['author'], publish_time=self._to_datetime(r['ts']), engagement={'likes': int(r['likes']) if str(r['likes']).isdigit() else 0}, source_table=r['source_table']) for r in raw_results]
-        return DBResponse("get_comments_for_topic", params_for_log, results=formatted, results_count=len(formatted))
+        formatted = [QueryResult(platform=r['platform'], content_type='comment', title_or_content=r['content'], author_nickname=r['author'], publish_time=self._to_datetime(r['ts']), engagement={'likes': int(r['likes']) if str(r['likes']).isdigit() else 0}, source_table=r['source_table'], record_id=str(r.get('record_id') or '')) for r in raw_results]
+        return DBResponse("get_comments_for_topic", params_for_log, results=formatted, results_count=len(formatted), tables=comment_tables, time_window={"kind": "unbounded"}, aggregation_method="record_lookup")
 
     def search_topic_on_platform(
         self,
@@ -392,9 +445,17 @@ class MediaCrawlerDB:
             for row in raw_results:
                 content = (row.get('title') or row.get('content') or row.get('desc') or row.get('content_text', ''))
                 time_key = config.get('time_col') and row.get(config.get('time_col'))
-                all_results.append(QueryResult(platform=platform, content_type=config['type'], title_or_content=content if content else '', author_nickname=row.get('nickname') or row.get('user_nickname'), url=row.get('video_url') or row.get('note_url') or row.get('content_url') or row.get('url') or row.get('aweme_url'), publish_time=self._to_datetime(time_key), engagement=self._extract_engagement(row), source_keyword=row.get('source_keyword'), source_table=table))
+                all_results.append(QueryResult(platform=platform, content_type=config['type'], title_or_content=content if content else '', author_nickname=row.get('nickname') or row.get('user_nickname'), url=row.get('video_url') or row.get('note_url') or row.get('content_url') or row.get('url') or row.get('aweme_url'), publish_time=self._to_datetime(time_key), engagement=self._extract_engagement(row), source_keyword=row.get('source_keyword'), source_table=table, record_id=str(row.get('id') or '')))
         
-        return DBResponse("search_topic_on_platform", params_for_log, results=all_results, results_count=len(all_results))
+        return DBResponse(
+            "search_topic_on_platform",
+            params_for_log,
+            results=all_results,
+            results_count=len(all_results),
+            time_window={"start": start_dt.isoformat(), "end": end_dt.isoformat()} if start_dt and end_dt else {},
+            tables=[item["table"] for item in platform_configs],
+            aggregation_method="record_lookup",
+        )
 
 # --- 3. 测试与使用示例 ---
 def print_response_summary(response: DBResponse):

--- a/MediaEngine/agent.py
+++ b/MediaEngine/agent.py
@@ -22,6 +22,13 @@ from .state import State
 from .tools import BochaMultimodalSearch, BochaResponse, AnspireAISearch, AnspireResponse
 from .utils import settings, Settings, format_search_results_for_prompt
 
+from common.provenance.io import save_sidecar
+from common.provenance.models import ProvenanceBundle
+from common.provenance.normalizer import (
+    add_search_results_to_bundle,
+    stable_id,
+)
+
 
 class DeepSearchAgent:
     """Deep Search Agent主类"""
@@ -69,6 +76,112 @@ class DeepSearchAgent:
         self.first_summary_node = FirstSummaryNode(self.llm_client)
         self.reflection_summary_node = ReflectionSummaryNode(self.llm_client)
         self.report_formatting_node = ReportFormattingNode(self.llm_client)
+
+    def _capture_provenance(
+        self,
+        search_results: List[Dict[str, Any]],
+        search_query: str,
+        paragraph_title: str,
+        search_tool: str,
+    ) -> None:
+        enriched_results = []
+        for result in search_results:
+            item = dict(result)
+            locator = dict(item.get("locator") or {})
+            for key in ("post_id", "comment_id", "timestamp"):
+                if item.get(key) not in (None, ""):
+                    locator[key] = item[key]
+            item["locator"] = locator
+            item["search_tool"] = search_tool
+            if locator.get("comment_id"):
+                item["source_type"] = item["evidence_type"] = "comment"
+            elif locator.get("timestamp") or locator.get("post_id"):
+                item["source_type"] = item["evidence_type"] = "video"
+            elif item.get("ocr_text"):
+                item["source_type"] = "social"
+                item["evidence_type"] = "ocr"
+                item["content"] = item.get("ocr_text")
+            else:
+                item["source_type"] = "web"
+                item["evidence_type"] = "web"
+            enriched_results.append(item)
+        self.state.provenance_bundle = add_search_results_to_bundle(
+            self.state.provenance_bundle,
+            agent="media_engine",
+            results=enriched_results,
+            query=search_query,
+            paragraph_title=paragraph_title,
+        )
+
+    def _capture_multimodal_artifacts(
+        self,
+        response: Any,
+        search_query: str,
+        paragraph_title: str,
+    ) -> None:
+        """Keep OCR/image/video locations without treating API summaries as evidence."""
+        records = []
+        for image in getattr(response, "images", []) or []:
+            snippet = str(getattr(image, "ocr_text", None) or getattr(image, "name", "") or "").strip()
+            if not snippet:
+                continue
+            url = str(getattr(image, "host_page_url", None) or getattr(image, "content_url", "") or "")
+            records.append(
+                {
+                    "title": str(getattr(image, "name", "") or "图像证据"),
+                    "url": url,
+                    "content": snippet,
+                    "ocr_text": getattr(image, "ocr_text", None),
+                    "source_type": "social",
+                    "evidence_type": "ocr" if getattr(image, "ocr_text", None) else "image_metadata",
+                    "locator": {"content_url": str(getattr(image, "content_url", "") or "")},
+                    "scope": {"subject": paragraph_title, "query": search_query},
+                }
+            )
+
+        for card in getattr(response, "modal_cards", []) or []:
+            content = getattr(card, "content", {}) or {}
+            if not isinstance(content, dict):
+                continue
+            card_type = str(getattr(card, "card_type", "multimodal") or "multimodal")
+            snippet = json.dumps(content, ensure_ascii=False, sort_keys=True)[:2000]
+            locator = {
+                "post_id": content.get("post_id") or content.get("postId"),
+                "comment_id": content.get("comment_id") or content.get("commentId"),
+                "timestamp": content.get("timestamp") or content.get("videoTimestamp"),
+            }
+            locator = {key: value for key, value in locator.items() if value not in (None, "")}
+            evidence_type = "comment" if locator.get("comment_id") else "video" if locator else "multimodal"
+            url = str(
+                content.get("url")
+                or content.get("sourceUrl")
+                or content.get("videoUrl")
+                or content.get("link")
+                or ""
+            )
+            records.append(
+                {
+                    "title": str(content.get("title") or content.get("name") or card_type),
+                    "url": url,
+                    "content": snippet,
+                    "normalized_value": content,
+                    "source_type": "video" if evidence_type == "video" else "social",
+                    "evidence_type": evidence_type,
+                    "locator": locator,
+                    "scope": {"subject": paragraph_title, "query": search_query, "card_type": card_type},
+                }
+            )
+
+        if records:
+            self.state.provenance_bundle = add_search_results_to_bundle(
+                self.state.provenance_bundle,
+                agent="media_engine",
+                results=records,
+                query=search_query,
+                paragraph_title=paragraph_title,
+                source_type="social",
+                evidence_type="multimodal",
+            )
     
     def _validate_date_format(self, date_str: str) -> bool:
         """
@@ -144,6 +257,12 @@ class DeepSearchAgent:
         logger.info(f"\n{'='*60}")
         logger.info(f"开始深度研究: {query}")
         logger.info(f"{'='*60}")
+
+        self.state.provenance_bundle = ProvenanceBundle(
+            agent="media_engine",
+            bundle_id=stable_id("bundle", "media_engine", query, datetime.now().isoformat()),
+            meta={"query": query},
+        )
         
         try:
             # Step 1: 生成报告结构
@@ -250,7 +369,11 @@ class DeepSearchAgent:
                     'content': result.snippet,
                     'score': None,  # Bocha API不提供score
                     'raw_content': result.snippet,
-                    'published_date': result.date_last_crawled  # 使用爬取日期
+                    'published_date': result.date_last_crawled,  # 使用爬取日期
+                    'post_id': result.post_id,
+                    'comment_id': result.comment_id,
+                    'timestamp': result.timestamp,
+                    'ocr_text': result.ocr_text,
                 })
         
         if search_results:
@@ -269,6 +392,8 @@ class DeepSearchAgent:
             search_tool=search_tool,
             paragraph_title=paragraph.title,
         )
+        self._capture_provenance(search_results, search_query, paragraph.title, search_tool)
+        self._capture_multimodal_artifacts(search_response, search_query, paragraph.title)
         
         # 生成初始总结
         logger.info("  - 生成初始总结...")
@@ -333,7 +458,11 @@ class DeepSearchAgent:
                         'content': result.snippet,
                         'score': None,  # Bocha API不提供score
                         'raw_content': result.snippet,
-                        'published_date': result.date_last_crawled
+                        'published_date': result.date_last_crawled,
+                        'post_id': result.post_id,
+                        'comment_id': result.comment_id,
+                        'timestamp': result.timestamp,
+                        'ocr_text': result.ocr_text,
                     })
             
             if search_results:
@@ -352,6 +481,8 @@ class DeepSearchAgent:
                 search_tool=search_tool,
                 paragraph_title=paragraph.title,
             )
+            self._capture_provenance(search_results, search_query, paragraph.title, search_tool)
+            self._capture_multimodal_artifacts(search_response, search_query, paragraph.title)
             
             # 生成反思总结
             reflection_summary_input = {
@@ -412,8 +543,11 @@ class DeepSearchAgent:
         # 保存报告
         with open(filepath, 'w', encoding='utf-8') as f:
             f.write(report_content)
+
+        sidecar = save_sidecar(self.state.provenance_bundle, filepath)
         
         logger.info(f"报告已保存到: {filepath}")
+        logger.info(f"证据审计文件已保存到: {sidecar}")
         
         # 保存状态（如果配置允许）
         if self.config.SAVE_INTERMEDIATE_STATES:

--- a/MediaEngine/state/state.py
+++ b/MediaEngine/state/state.py
@@ -8,6 +8,8 @@ from typing import List, Dict, Any, Optional
 import json
 from datetime import datetime
 
+from common.provenance.models import ProvenanceBundle
+
 
 @dataclass
 class Search:
@@ -16,6 +18,9 @@ class Search:
     url: str = ""                      # 搜索结果的链接
     title: str = ""                    # 搜索结果标题
     content: str = ""                  # 搜索返回的内容
+    raw_content: str = ""              # 正文或OCR片段
+    publish_time: str = ""             # 来源发布时间
+    locator: Dict[str, Any] = field(default_factory=dict)
     score: Optional[float] = None      # 相关度评分
     paragraph_title: str = ""          # 段落标题，便于展示归属
     search_tool: str = ""              # 使用的搜索工具
@@ -29,6 +34,9 @@ class Search:
             "url": self.url,
             "title": self.title,
             "content": self.content,
+            "raw_content": self.raw_content,
+            "publish_time": self.publish_time,
+            "locator": self.locator,
             "score": self.score,
             "paragraph_title": self.paragraph_title,
             "search_tool": self.search_tool,
@@ -44,6 +52,9 @@ class Search:
             url=data.get("url", ""),
             title=data.get("title", ""),
             content=data.get("content", ""),
+            raw_content=data.get("raw_content", ""),
+            publish_time=data.get("publish_time", data.get("published_date", "")),
+            locator=data.get("locator", {}) or {},
             score=data.get("score"),
             paragraph_title=data.get("paragraph_title", ""),
             search_tool=data.get("search_tool", ""),
@@ -94,6 +105,9 @@ class Research:
                     url=url,
                     title=title,
                     content=content,
+                    raw_content=result.get("raw_content", ""),
+                    publish_time=result.get("publish_time", result.get("published_date", "")),
+                    locator=result.get("locator", {}) or {},
                     score=result.get("score"),
                     paragraph_title=paragraph_title or result.get("paragraph_title", ""),
                     search_tool=search_tool or result.get("search_tool", ""),
@@ -180,6 +194,7 @@ class State:
     report_title: str = ""                                         # 报告标题
     paragraphs: List[Paragraph] = field(default_factory=list)     # 段落列表
     final_report: str = ""                                         # 最终报告内容
+    provenance_bundle: ProvenanceBundle = field(default_factory=lambda: ProvenanceBundle(agent="media_engine"))
     is_completed: bool = False                                     # 是否完成
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
@@ -249,6 +264,7 @@ class State:
             "report_title": self.report_title,
             "paragraphs": [p.to_dict() for p in self.paragraphs],
             "final_report": self.final_report,
+            "provenance_bundle": self.provenance_bundle.to_dict(),
             "is_completed": self.is_completed,
             "created_at": self.created_at,
             "updated_at": self.updated_at
@@ -268,6 +284,7 @@ class State:
             report_title=data.get("report_title", ""),
             paragraphs=paragraphs,
             final_report=data.get("final_report", ""),
+            provenance_bundle=ProvenanceBundle.from_dict(data.get("provenance_bundle")),
             is_completed=data.get("is_completed", False),
             created_at=data.get("created_at", datetime.now().isoformat()),
             updated_at=data.get("updated_at", datetime.now().isoformat())

--- a/MediaEngine/tools/search.py
+++ b/MediaEngine/tools/search.py
@@ -55,6 +55,10 @@ class WebpageResult:
     snippet: str
     display_url: Optional[str] = None
     date_last_crawled: Optional[str] = None
+    post_id: Optional[str] = None
+    comment_id: Optional[str] = None
+    timestamp: Optional[str] = None
+    ocr_text: Optional[str] = None
 
 @dataclass
 class ImageResult:
@@ -65,6 +69,7 @@ class ImageResult:
     thumbnail_url: Optional[str] = None
     width: Optional[int] = None
     height: Optional[int] = None
+    ocr_text: Optional[str] = None
 
 @dataclass
 class ModalCardResult:
@@ -159,7 +164,11 @@ class BochaMultimodalSearch:
                             url=item.get('url'),
                             snippet=item.get('snippet'),
                             display_url=item.get('displayUrl'),
-                            date_last_crawled=item.get('dateLastCrawled')
+                            date_last_crawled=item.get('dateLastCrawled'),
+                            post_id=item.get('postId') or item.get('post_id'),
+                            comment_id=item.get('commentId') or item.get('comment_id'),
+                            timestamp=item.get('timestamp') or item.get('videoTimestamp'),
+                            ocr_text=item.get('ocrText') or item.get('ocr_text'),
                         ))
                 elif content_type == 'image':
                     final_response.images.append(ImageResult(
@@ -168,7 +177,8 @@ class BochaMultimodalSearch:
                         host_page_url=content_data.get('hostPageUrl'),
                         thumbnail_url=content_data.get('thumbnailUrl'),
                         width=content_data.get('width'),
-                        height=content_data.get('height')
+                        height=content_data.get('height'),
+                        ocr_text=content_data.get('ocrText') or content_data.get('ocr_text')
                     ))
                 # 所有其他 content_type 都视为模态卡
                 else:

--- a/QueryEngine/agent.py
+++ b/QueryEngine/agent.py
@@ -23,6 +23,10 @@ from .tools import TavilyNewsAgency, TavilyResponse
 from .utils import Settings, format_search_results_for_prompt
 from loguru import logger
 
+from common.provenance.io import save_sidecar
+from common.provenance.models import ProvenanceBundle
+from common.provenance.normalizer import add_search_results_to_bundle, stable_id
+
 class DeepSearchAgent:
     """Deep Search Agent主类"""
     
@@ -71,6 +75,28 @@ class DeepSearchAgent:
         self.first_summary_node = FirstSummaryNode(self.llm_client)
         self.reflection_summary_node = ReflectionSummaryNode(self.llm_client)
         self.report_formatting_node = ReportFormattingNode(self.llm_client)
+
+    def _capture_provenance(
+        self,
+        search_results: List[Dict[str, Any]],
+        search_query: str,
+        paragraph_title: str,
+        search_tool: str,
+    ) -> None:
+        enriched_results = []
+        for result in search_results:
+            item = dict(result)
+            item["search_tool"] = search_tool
+            item["source_type"] = "web"
+            item["evidence_type"] = "web"
+            enriched_results.append(item)
+        self.state.provenance_bundle = add_search_results_to_bundle(
+            self.state.provenance_bundle,
+            agent="query_engine",
+            results=enriched_results,
+            query=search_query,
+            paragraph_title=paragraph_title,
+        )
     
     def _validate_date_format(self, date_str: str) -> bool:
         """
@@ -152,6 +178,12 @@ class DeepSearchAgent:
         logger.info(f"\n{'='*60}")
         logger.info(f"开始深度研究: {query}")
         logger.info(f"{'='*60}")
+
+        self.state.provenance_bundle = ProvenanceBundle(
+            agent="query_engine",
+            bundle_id=stable_id("bundle", "query_engine", query, datetime.now().isoformat()),
+            meta={"query": query},
+        )
         
         try:
             # Step 1: 生成报告结构
@@ -285,6 +317,7 @@ class DeepSearchAgent:
             logger.info("  - 未找到搜索结果")
         # 更新状态中的搜索历史
         paragraph.research.add_search_results(search_query, search_results)
+        self._capture_provenance(search_results, search_query, paragraph.title, search_tool)
         
         # 生成初始总结
         logger.info("  - 生成初始总结...")
@@ -376,6 +409,7 @@ class DeepSearchAgent:
             
             # 更新搜索历史
             paragraph.research.add_search_results(search_query, search_results)
+            self._capture_provenance(search_results, search_query, paragraph.title, search_tool)
             
             # 生成反思总结
             reflection_summary_input = {
@@ -436,8 +470,11 @@ class DeepSearchAgent:
         # 保存报告
         with open(filepath, 'w', encoding='utf-8') as f:
             f.write(report_content)
+
+        sidecar = save_sidecar(self.state.provenance_bundle, filepath)
         
         logger.info(f"报告已保存到: {filepath}")
+        logger.info(f"证据审计文件已保存到: {sidecar}")
         
         # 保存状态（如果配置允许）
         if self.config.SAVE_INTERMEDIATE_STATES:

--- a/QueryEngine/state/state.py
+++ b/QueryEngine/state/state.py
@@ -8,6 +8,8 @@ from typing import List, Dict, Any, Optional
 import json
 from datetime import datetime
 
+from common.provenance.models import ProvenanceBundle
+
 
 @dataclass
 class Search:
@@ -16,6 +18,10 @@ class Search:
     url: str = ""                      # 搜索结果的链接
     title: str = ""                    # 搜索结果标题
     content: str = ""                  # 搜索返回的内容
+    raw_content: str = ""              # 可引用的正文片段
+    publish_time: str = ""             # 来源发布时间
+    domain: str = ""                   # 来源域名
+    locator: Dict[str, Any] = field(default_factory=dict)
     score: Optional[float] = None      # 相关度评分
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     
@@ -26,6 +32,10 @@ class Search:
             "url": self.url,
             "title": self.title,
             "content": self.content,
+            "raw_content": self.raw_content,
+            "publish_time": self.publish_time,
+            "domain": self.domain,
+            "locator": self.locator,
             "score": self.score,
             "timestamp": self.timestamp
         }
@@ -38,6 +48,10 @@ class Search:
             url=data.get("url", ""),
             title=data.get("title", ""),
             content=data.get("content", ""),
+            raw_content=data.get("raw_content", ""),
+            publish_time=data.get("publish_time", data.get("published_date", "")),
+            domain=data.get("domain", ""),
+            locator=data.get("locator", {}) or {},
             score=data.get("score"),
             timestamp=data.get("timestamp", datetime.now().isoformat())
         )
@@ -63,6 +77,10 @@ class Research:
                 url=result.get("url", ""),
                 title=result.get("title", ""),
                 content=result.get("content", ""),
+                raw_content=result.get("raw_content", ""),
+                publish_time=result.get("publish_time", result.get("published_date", "")),
+                domain=result.get("domain", ""),
+                locator=result.get("locator", {}) or {},
                 score=result.get("score")
             )
             self.add_search(search)
@@ -146,6 +164,7 @@ class State:
     report_title: str = ""                                         # 报告标题
     paragraphs: List[Paragraph] = field(default_factory=list)     # 段落列表
     final_report: str = ""                                         # 最终报告内容
+    provenance_bundle: ProvenanceBundle = field(default_factory=lambda: ProvenanceBundle(agent="query_engine"))
     is_completed: bool = False                                     # 是否完成
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
@@ -215,6 +234,7 @@ class State:
             "report_title": self.report_title,
             "paragraphs": [p.to_dict() for p in self.paragraphs],
             "final_report": self.final_report,
+            "provenance_bundle": self.provenance_bundle.to_dict(),
             "is_completed": self.is_completed,
             "created_at": self.created_at,
             "updated_at": self.updated_at
@@ -234,6 +254,7 @@ class State:
             report_title=data.get("report_title", ""),
             paragraphs=paragraphs,
             final_report=data.get("final_report", ""),
+            provenance_bundle=ProvenanceBundle.from_dict(data.get("provenance_bundle")),
             is_completed=data.get("is_completed", False),
             created_at=data.get("created_at", datetime.now().isoformat()),
             updated_at=data.get("updated_at", datetime.now().isoformat())

--- a/ReportEngine/agent.py
+++ b/ReportEngine/agent.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from pathlib import Path
 from uuid import uuid4
 from datetime import datetime
-from typing import Optional, Dict, Any, List, Callable, Tuple
+from typing import Optional, Dict, Any, List, Callable, Mapping, Tuple
 
 from loguru import logger
 
@@ -38,6 +38,11 @@ from .nodes import (
 from .renderers import HTMLRenderer
 from .state import ReportState
 from .utils.config import settings, Settings
+
+from common.provenance.io import load_sidecar, save_sidecar
+from common.provenance.models import ProvenanceBundle
+from common.provenance.normalizer import merge_bundles
+from common.provenance.validators import filter_valid_evidence
 
 
 class StageOutputFormatError(ValueError):
@@ -404,7 +409,8 @@ class ReportAgent:
     
     def generate_report(self, query: str, reports: List[Any], forum_logs: str = "",
                         custom_template: str = "", save_report: bool = True,
-                        stream_handler: Optional[Callable[[str, Dict[str, Any]], None]] = None) -> str:
+                        stream_handler: Optional[Callable[[str, Dict[str, Any]], None]] = None,
+                        provenance_bundle: Optional[Any] = None) -> str:
         """
         生成综合报告（章节JSON → IR → HTML）。
 
@@ -437,6 +443,8 @@ class ReportAgent:
         self.state.mark_processing()
 
         normalized_reports = self._normalize_reports(reports)
+        runtime_bundle = self._normalize_provenance_bundle(provenance_bundle, reports)
+        self.state.provenance_bundle = runtime_bundle
 
         def emit(event_type: str, payload: Dict[str, Any]):
             """面向Report Engine流通道的事件分发器，保证错误不外泄。"""
@@ -452,7 +460,9 @@ class ReportAgent:
         emit('stage', {'stage': 'agent_start', 'report_id': report_id, 'query': query})
 
         try:
-            template_result = self._select_template(query, reports, forum_logs, custom_template)
+            template_result = self._select_template(
+                query, list(normalized_reports.values()), forum_logs, custom_template
+            )
             template_result = self._ensure_mapping(
                 template_result,
                 "模板选择结果",
@@ -486,6 +496,7 @@ class ReportAgent:
                 # toc 字段已被 tocPlan 取代，这里按最新Schema挑选/校验
                 expected_keys=["title", "hero", "tocPlan", "tocTitle"],
             )
+            layout_design = self._sanitize_layout_for_provenance(layout_design, runtime_bundle)
             emit('stage', {
                 'stage': 'layout_designed',
                 'title': layout_design.get('title'),
@@ -527,6 +538,7 @@ class ReportAgent:
                 chapter_targets,
                 word_plan,
                 template_overview,
+                runtime_bundle,
             )
             # IR/渲染需要的全局元数据，带上设计稿给出的标题/主题/目录/篇幅信息
             manifest_meta = {
@@ -745,7 +757,8 @@ class ReportAgent:
             document_ir = self.document_composer.build_document(
                 report_id,
                 manifest_meta,
-                chapters
+                chapters,
+                runtime_bundle,
             )
             emit('stage', {'stage': 'chapters_compiled', 'chapter_count': len(chapters)})
             html_report = self.renderer.render(document_ir)
@@ -870,6 +883,7 @@ class ReportAgent:
         chapter_directives: Dict[str, Any],
         word_plan: Dict[str, Any],
         template_overview: Dict[str, Any],
+        provenance_bundle: ProvenanceBundle,
     ) -> Dict[str, Any]:
         """
         构造章节生成所需的共享上下文。
@@ -914,6 +928,9 @@ class ReportAgent:
             "template_overview": template_overview or {},
             "chapter_directives": chapter_directives or {},
             "word_plan": word_plan or {},
+            "provenance_bundle": provenance_bundle,
+            "evidence_top_k": self.config.PROVENANCE_EVIDENCE_TOP_K,
+            "enforce_provenance": True,
         }
 
     def _normalize_reports(self, reports: List[Any]) -> Dict[str, str]:
@@ -933,8 +950,53 @@ class ReportAgent:
         normalized: Dict[str, str] = {}
         for idx, key in enumerate(keys):
             value = reports[idx] if idx < len(reports) else ""
+            if isinstance(value, Mapping):
+                value = (
+                    value.get("content")
+                    or value.get("report")
+                    or value.get("text")
+                    or value.get("final_report")
+                    or ""
+                )
             normalized[key] = self._stringify(value)
         return normalized
+
+    def _normalize_provenance_bundle(
+        self,
+        explicit_bundle: Optional[Any],
+        reports: List[Any],
+    ) -> ProvenanceBundle:
+        bundles: List[Any] = []
+        if isinstance(explicit_bundle, (list, tuple)):
+            bundles.extend(explicit_bundle)
+        elif explicit_bundle:
+            bundles.append(explicit_bundle)
+        for report in reports:
+            if not isinstance(report, Mapping):
+                continue
+            bundle = report.get("provenance_bundle") or report.get("provenance")
+            if bundle:
+                bundles.append(bundle)
+        return filter_valid_evidence(merge_bundles(bundles))
+
+    def _sanitize_layout_for_provenance(
+        self,
+        layout: Dict[str, Any],
+        bundle: ProvenanceBundle,
+    ) -> Dict[str, Any]:
+        sanitized = deepcopy(layout or {})
+        evidence_count = len(bundle.evidence)
+        sanitized["hero"] = {
+            "summary": (
+                f"本报告基于 {evidence_count} 条可追溯证据生成，正文引用可查看来源详情。"
+                if evidence_count
+                else "当前未检索到可追溯证据，正文仅保留证据状态说明。"
+            ),
+            "highlights": [],
+            "kpis": [],
+            "actions": [],
+        }
+        return sanitized
 
     def _should_retry_inappropriate_content_error(self, error: Exception) -> bool:
         """
@@ -1342,9 +1404,14 @@ class ReportAgent:
         state_abs = str(state_path.resolve())
         state_rel = os.path.relpath(state_abs, os.getcwd())
 
+        provenance_path = save_sidecar(self.state.provenance_bundle, html_path)
+        provenance_abs = str(provenance_path.resolve())
+        provenance_rel = os.path.relpath(provenance_abs, os.getcwd())
+
         logger.info(f"HTML报告已保存: {html_path}")
         logger.info(f"Document IR已保存: {ir_path}")
         logger.info(f"状态已保存到: {state_path}")
+        logger.info(f"证据审计文件已保存: {provenance_path}")
         
         return {
             'report_filename': html_filename,
@@ -1356,6 +1423,9 @@ class ReportAgent:
             'state_filename': state_filename,
             'state_filepath': state_abs,
             'state_relative_path': state_rel,
+            'provenance_filename': provenance_path.name,
+            'provenance_filepath': provenance_abs,
+            'provenance_relative_path': provenance_rel,
         }
 
     def _save_document_ir(self, document_ir: Dict[str, Any], query_safe: str, timestamp: str) -> Path:
@@ -1502,8 +1572,10 @@ class ReportAgent:
         """
         content = {
             'reports': [],
-            'forum_logs': ''
+            'forum_logs': '',
+            'provenance_bundle': ProvenanceBundle(agent="report_engine"),
         }
+        sidecar_bundles = []
         
         # 加载报告文件
         engines = ['query', 'media', 'insight']
@@ -1513,10 +1585,15 @@ class ReportAgent:
                     with open(file_paths[engine], 'r', encoding='utf-8') as f:
                         report_content = f.read()
                     content['reports'].append(report_content)
+                    sidecar_bundle = load_sidecar(file_paths[engine])
+                    if sidecar_bundle.evidence:
+                        sidecar_bundles.append(sidecar_bundle)
                     logger.info(f"已加载 {engine} 报告: {len(report_content)} 字符")
                 except Exception as e:
                     logger.exception(f"加载 {engine} 报告失败: {str(e)}")
                     content['reports'].append("")
+
+        content['provenance_bundle'] = merge_bundles(sidecar_bundles)
         
         # 加载论坛日志
         if 'forum' in file_paths:

--- a/ReportEngine/core/stitcher.py
+++ b/ReportEngine/core/stitcher.py
@@ -7,9 +7,13 @@ DocumentComposer 会注入缺失锚点、统一顺序，并补齐 IR 级元数�
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Set
+import copy
+from typing import Any, Dict, List, Mapping, Optional, Set
 
 from ..ir import IR_VERSION
+from common.provenance.models import ClaimRecord, ProvenanceBundle
+from common.provenance.normalizer import merge_bundles
+from common.provenance.validators import filter_valid_evidence, gate_claims, sanitize_blocks
 
 
 class DocumentComposer:
@@ -31,6 +35,7 @@ class DocumentComposer:
         report_id: str,
         metadata: Dict[str, object],
         chapters: List[Dict[str, object]],
+        provenance_bundle: Optional[ProvenanceBundle | Mapping[str, Any] | List[Any]] = None,
     ) -> Dict[str, object]:
         """
         把所有章节按order排序并注入唯一锚点，形成整本IR。
@@ -46,9 +51,10 @@ class DocumentComposer:
             dict: 满足渲染器需求的Document IR。
         """
         # 构建从chapterId到toc anchor的映射
+        self._seen_anchors.clear()
         toc_anchor_map = self._build_toc_anchor_map(metadata)
 
-        ordered = sorted(chapters, key=lambda c: c.get("order", 0))
+        ordered = sorted(copy.deepcopy(chapters), key=lambda c: c.get("order", 0))
         for idx, chapter in enumerate(ordered, start=1):
             chapter.setdefault("chapterId", f"S{idx}")
 
@@ -64,6 +70,27 @@ class DocumentComposer:
             if chapter.get("errorPlaceholder"):
                 self._ensure_heading_block(chapter)
 
+        if isinstance(provenance_bundle, list):
+            merged_bundle = merge_bundles(provenance_bundle)
+        elif isinstance(provenance_bundle, ProvenanceBundle):
+            merged_bundle = merge_bundles([provenance_bundle])
+        elif isinstance(provenance_bundle, Mapping):
+            merged_bundle = merge_bundles([provenance_bundle])
+        else:
+            merged_bundle = ProvenanceBundle(agent="report_engine")
+
+        merged_bundle = filter_valid_evidence(merged_bundle)
+        if provenance_bundle is not None:
+            for chapter in ordered:
+                chapter["blocks"] = sanitize_blocks(chapter.get("blocks", []), merged_bundle)
+        chapter_claims: List[ClaimRecord] = []
+        for chapter in ordered:
+            self._collect_nested_claims(chapter.get("blocks", []), chapter_claims)
+        accepted_claims, _ = gate_claims(
+            chapter_claims, merged_bundle
+        )
+        merged_bundle.claims = self._dedupe_claims(accepted_claims)
+
         document = {
             "version": IR_VERSION,
             "reportId": report_id,
@@ -75,8 +102,49 @@ class DocumentComposer:
             "themeTokens": metadata.get("themeTokens", {}),
             "chapters": ordered,
             "assets": metadata.get("assets", {}),
+            "provenanceBundle": merged_bundle.to_dict(),
+            "provenanceIndex": {
+                "sources": {item.source_id: item.to_dict() for item in merged_bundle.sources},
+                "evidence": {item.evidence_id: item.to_dict() for item in merged_bundle.evidence},
+            },
+            "claimIndex": {item.claim_id: item.to_dict() for item in merged_bundle.claims},
+            "provenanceEnforced": provenance_bundle is not None,
         }
         return document
+
+
+    def _collect_nested_claims(self, blocks: Any, claims: List[ClaimRecord]) -> None:
+        if not isinstance(blocks, list):
+            return
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            claims.extend(
+                ClaimRecord.from_dict(item)
+                for item in block.get("claims", []) or []
+                if isinstance(item, Mapping)
+            )
+            self._collect_nested_claims(block.get("blocks"), claims)
+            for item in block.get("items", []) or []:
+                self._collect_nested_claims(item, claims)
+            for row in block.get("rows", []) or []:
+                if not isinstance(row, dict):
+                    continue
+                for cell in row.get("cells", []) or []:
+                    if isinstance(cell, dict):
+                        self._collect_nested_claims(cell.get("blocks"), claims)
+
+    @staticmethod
+    def _dedupe_claims(claims: List[ClaimRecord]) -> List[ClaimRecord]:
+        result: List[ClaimRecord] = []
+        seen = set()
+        for claim in claims:
+            key = claim.claim_id or (claim.claim_type, claim.text, tuple(claim.evidence_ids))
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(claim)
+        return result
 
     def _ensure_unique_anchor(self, anchor: str) -> str:
         """若存在重复锚点则追加序号，确保全局唯一。"""

--- a/ReportEngine/core/stitcher.py
+++ b/ReportEngine/core/stitcher.py
@@ -83,6 +83,8 @@ class DocumentComposer:
         if provenance_bundle is not None:
             for chapter in ordered:
                 chapter["blocks"] = sanitize_blocks(chapter.get("blocks", []), merged_bundle)
+                if not chapter["blocks"]:
+                    self._ensure_heading_block(chapter)
         chapter_claims: List[ClaimRecord] = []
         for chapter in ordered:
             self._collect_nested_claims(chapter.get("blocks", []), chapter_claims)

--- a/ReportEngine/flask_interface.py
+++ b/ReportEngine/flask_interface.py
@@ -21,6 +21,7 @@ from loguru import logger
 from .agent import ReportAgent, create_agent
 from .nodes import ChapterJsonParseError
 from .utils.config import settings
+from common.provenance.runtime import runtime_store
 
 
 # 创建Blueprint
@@ -404,7 +405,7 @@ class ReportTask:
             return [evt for evt in self.event_history if evt['id'] > last_event_id]
 
 
-def check_engines_ready() -> Dict[str, Any]:
+def check_engines_ready(run_id: str = '') -> Dict[str, Any]:
     """
     检查三个子引擎是否都有新文件。
 
@@ -419,6 +420,8 @@ def check_engines_ready() -> Dict[str, Any]:
 
     forum_log_path = 'logs/forum.log'
 
+    if run_id:
+        return runtime_store.status(run_id)
     if not report_agent:
         return {
             'ready': False,
@@ -433,7 +436,7 @@ def check_engines_ready() -> Dict[str, Any]:
     )
 
 
-def run_report_generation(task: ReportTask, query: str, custom_template: str = ""):
+def run_report_generation(task: ReportTask, query: str, custom_template: str = "", run_id: str = ''):
     """
     在后台线程中运行报告生成。
 
@@ -460,7 +463,7 @@ def run_report_generation(task: ReportTask, query: str, custom_template: str = "
         task.publish_event('stage', {'message': '任务已启动，正在检查输入文件', 'stage': 'prepare'})
 
         # 检查输入文件
-        check_result = check_engines_ready()
+        check_result = check_engines_ready(run_id)
         if not check_result['ready']:
             task.update_status("error", 0, f"输入文件未准备就绪: {check_result.get('missing_files', [])}")
             return
@@ -472,7 +475,7 @@ def run_report_generation(task: ReportTask, query: str, custom_template: str = "
         })
 
         # 加载输入文件
-        content = report_agent.load_input_files(check_result['latest_files'])
+        content = runtime_store.inputs(run_id, query) if run_id else report_agent.load_input_files(check_result['latest_files'])
         task.publish_event('stage', {'message': '源数据加载完成，启动生成流程', 'stage': 'data_loaded'})
 
         # 生成报告（附带兜底重试，缓解瞬时网络抖动）
@@ -489,7 +492,8 @@ def run_report_generation(task: ReportTask, query: str, custom_template: str = "
                     forum_logs=content['forum_logs'],
                     custom_template=custom_template,
                     save_report=True,
-                    stream_handler=stream_handler
+                    stream_handler=stream_handler,
+                    provenance_bundle=content.get('provenance_bundle'),
                 )
                 break
             except ChapterJsonParseError as err:
@@ -583,7 +587,7 @@ def get_status():
         Response: JSON结构包含initialized/engines_ready/当前任务等。
     """
     try:
-        engines_status = check_engines_ready()
+        engines_status = check_engines_ready(request.args.get('run_id', ''))
 
         return jsonify({
             'success': True,
@@ -638,6 +642,7 @@ def generate_report():
             data = {}
         query = data.get('query', '智能舆情分析报告')
         custom_template = data.get('custom_template', '')
+        run_id = data.get('run_id', '')
 
         # 清空日志文件
         clear_report_log()
@@ -650,7 +655,7 @@ def generate_report():
             }), 500
 
         # 检查输入文件是否准备就绪
-        engines_status = check_engines_ready()
+        engines_status = check_engines_ready(run_id)
         if not engines_status['ready']:
             return jsonify({
                 'success': False,
@@ -681,7 +686,7 @@ def generate_report():
         # 在后台线程中运行报告生成
         thread = threading.Thread(
             target=run_report_generation,
-            args=(task, query, custom_template),
+            args=(task, query, custom_template, run_id),
             daemon=True
         )
         thread.start()

--- a/ReportEngine/ir/schema.py
+++ b/ReportEngine/ir/schema.py
@@ -110,6 +110,46 @@ paragraph_block: Dict[str, Any] = {
     "additionalProperties": True,
 }
 
+claim_record_schema: Dict[str, Any] = {
+    "type": "object",
+    "required": ["claim_id", "text", "claim_type", "evidence_ids", "support_status"],
+    "properties": {
+        "claim_id": {"type": "string"},
+        "text": {"type": "string"},
+        "claim_type": {
+            "type": "string",
+            "enum": ["fact", "metric", "inference", "prediction", "recommendation"],
+        },
+        "text_span": {
+            "type": "object",
+            "properties": {
+                "start": {"type": "integer", "minimum": 0},
+                "end": {"type": "integer", "minimum": 0},
+            },
+            "additionalProperties": True,
+        },
+        "evidence_ids": {"type": "array", "items": {"type": "string"}},
+        "support_status": {
+            "type": "string",
+            "enum": ["supported", "weak", "unsupported", "predicted"],
+        },
+        "scope": {"type": "object"},
+    },
+    "additionalProperties": True,
+}
+
+block_provenance_properties: Dict[str, Any] = {
+    "claims": {
+        "type": "array",
+        "items": {"$ref": "#/definitions/claimRecord"},
+    },
+    "citation_refs": {"type": "array", "items": {"type": "string"}},
+    "support_status": {
+        "type": "string",
+        "enum": ["supported", "weak", "unsupported", "predicted"],
+    },
+}
+
 list_block: Dict[str, Any] = {
     "title": "ListBlock",
     "type": "object",
@@ -498,6 +538,9 @@ block_variants: List[Dict[str, Any]] = [
     pest_block,
 ]
 
+for _block_schema in block_variants:
+    _block_schema.setdefault("properties", {}).update(block_provenance_properties)
+
 CHAPTER_JSON_SCHEMA: Dict[str, Any] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "ReportEngineChapterIR",
@@ -525,6 +568,7 @@ CHAPTER_JSON_SCHEMA: Dict[str, Any] = {
         "inlineRun": inline_run_schema,
         "swotItem": swot_item_schema,
         "pestItem": pest_item_schema,
+        "claimRecord": claim_record_schema,
         "block": {"oneOf": block_variants},
     },
 }
@@ -542,4 +586,5 @@ __all__ = [
     "CHAPTER_JSON_SCHEMA",
     "CHAPTER_JSON_SCHEMA_TEXT",
     "ENGINE_AGENT_TITLES",
+    "claim_record_schema",
 ]

--- a/ReportEngine/nodes/chapter_generation_node.py
+++ b/ReportEngine/nodes/chapter_generation_node.py
@@ -417,14 +417,7 @@ class ChapterGenerationNode(BaseNode):
                     "level": 2,
                     "text": section.title,
                     "anchor": section.slug,
-                },
-                {
-                    "type": "paragraph",
-                    "inlines": [{"text": "本章未检索到可追溯证据。"}],
-                    "claims": [],
-                    "citation_refs": [],
-                    "support_status": "unsupported",
-                },
+                }
             ],
         }
 

--- a/ReportEngine/nodes/chapter_generation_node.py
+++ b/ReportEngine/nodes/chapter_generation_node.py
@@ -32,6 +32,9 @@ from ..prompts import (
 )
 from ..utils.json_parser import RobustJSONParser, JSONParseError
 from .base_node import BaseNode
+from common.provenance.models import ProvenanceBundle
+from common.provenance.selector import EvidenceSelector
+from common.provenance.validators import sanitize_blocks
 
 try:
     from json_repair import repair_json as _json_repair_fn
@@ -167,6 +170,7 @@ class ChapterGenerationNode(BaseNode):
             enable_json_repair=True,
             enable_llm_repair=False,
         )
+        self.evidence_selector = EvidenceSelector(top_k=8)
 
     def run(
         self,
@@ -203,6 +207,11 @@ class ChapterGenerationNode(BaseNode):
         run_id = run_dir.name
         self._ensure_run_state(run_id)
         llm_payload = self._build_payload(section, context)
+        selected_evidence = (llm_payload.get("selectedEvidence") or {}).get("evidence", [])
+        if context.get("enforce_provenance", False) and not selected_evidence:
+            chapter_json = self._build_no_evidence_chapter(section)
+            self.storage.persist_chapter(run_dir, chapter_meta, chapter_json, errors=None)
+            return chapter_json
         user_message = build_chapter_user_prompt(llm_payload)
 
         raw_text = self._stream_llm(
@@ -243,6 +252,9 @@ class ChapterGenerationNode(BaseNode):
         chapter_json.setdefault("title", section.title)
         chapter_json.setdefault("order", section.order)
         self._sanitize_chapter_blocks(chapter_json)
+        if context.get("enforce_provenance", False):
+            selected_bundle = ProvenanceBundle.from_dict(llm_payload["selectedEvidence"])
+            self._sanitize_provenance_claims(chapter_json, selected_bundle)
 
         valid, errors = self.validator.validate_chapter(chapter_json)
         if not valid and errors:
@@ -258,9 +270,11 @@ class ChapterGenerationNode(BaseNode):
                 chapter_json.setdefault("title", section.title)
                 chapter_json.setdefault("order", section.order)
                 self._sanitize_chapter_blocks(chapter_json)
+                if context.get("enforce_provenance", False):
+                    self._sanitize_provenance_claims(chapter_json, selected_bundle)
                 valid, errors = self.validator.validate_chapter(chapter_json)
         content_error: ChapterContentError | None = None
-        if valid and not placeholder_created:
+        if valid and not placeholder_created and not context.get("enforce_provenance", False):
             try:
                 self._ensure_content_density(chapter_json)
             except ChapterContentError as exc:
@@ -311,6 +325,23 @@ class ChapterGenerationNode(BaseNode):
         allow_swot = self._get_chapter_swot_permission(section.chapter_id, context)
         allow_pest = self._get_chapter_pest_permission(section.chapter_id, context)
 
+        chapter_plan_text = json.dumps(chapter_plan or {}, ensure_ascii=False)
+        selected_bundle = self.evidence_selector.select(
+            context.get("provenance_bundle"),
+            chapter_topic=section.title,
+            chapter_draft=" ".join(section.outline or []) + " " + chapter_plan_text,
+            claim_drafts=(chapter_plan or {}).get("emphasis") or [],
+            top_k=context.get("evidence_top_k", 8),
+        )
+        full_bundle = context.get("provenance_bundle")
+        if isinstance(full_bundle, ProvenanceBundle):
+            source_evidence = {item.evidence_id: item for item in full_bundle.evidence}
+            for selected in selected_bundle.evidence:
+                original = source_evidence.get(selected.evidence_id)
+                if original is not None:
+                    original.meta["selection_reason"] = selected.meta.get("selection_reason", "")
+                    original.meta["selection_score"] = selected.meta.get("selection_score", 0)
+
         payload = {
             "section": {
                 "chapterId": section.chapter_id,
@@ -330,20 +361,28 @@ class ChapterGenerationNode(BaseNode):
                 "templateOverview": context.get("template_overview", {}),
             },
             "reports": {
-                "query_engine": reports.get("query_engine", ""),
-                "media_engine": reports.get("media_engine", ""),
-                "insight_engine": reports.get("insight_engine", ""),
+                "query_engine": "",
+                "media_engine": "",
+                "insight_engine": "",
             },
             "forumLogs": context.get("forum_logs", ""),
-            "dataBundles": context.get("data_bundles", []),
+            "dataBundles": [],
+            "selectedEvidence": selected_bundle.to_dict(),
+            "provenancePolicy": {
+                "reportsAreContextOnly": True,
+                "forumTextIsNotEvidence": True,
+                "factMetricRequireEvidenceIds": True,
+                "inferenceMinimumEvidence": 2,
+                "predictionMustBeSeparated": True,
+            },
             "constraints": {
                 "language": "zh-CN",
                 "maxTokens": context.get("max_tokens", 4096),
-                "allowedBlocks": ALLOWED_BLOCK_TYPES,
+                "allowedBlocks": ["heading", "paragraph", "list"],
                 "allowSwot": allow_swot,
                 "allowPest": allow_pest,
                 "styleHints": {
-                    "expectWidgets": True,
+                    "expectWidgets": False,
                     "forceHeadingAnchors": True,
                     "allowInlineMix": True,
                 },
@@ -365,6 +404,32 @@ class ChapterGenerationNode(BaseNode):
                 constraints["sectionBudgets"] = chapter_plan["sections"]
                 payload["globalContext"]["sectionBudgets"] = chapter_plan["sections"]
         return payload
+
+    def _build_no_evidence_chapter(self, section: TemplateSection) -> Dict[str, Any]:
+        return {
+            "chapterId": section.chapter_id,
+            "anchor": section.slug,
+            "title": section.title,
+            "order": section.order,
+            "blocks": [
+                {
+                    "type": "heading",
+                    "level": 2,
+                    "text": section.title,
+                    "anchor": section.slug,
+                },
+                {
+                    "type": "paragraph",
+                    "inlines": [{"text": "本章未检索到可追溯证据。"}],
+                    "claims": [],
+                    "citation_refs": [],
+                    "support_status": "unsupported",
+                },
+            ],
+        }
+
+    def _sanitize_provenance_claims(self, chapter: Dict[str, Any], evidence: ProvenanceBundle) -> None:
+        chapter["blocks"] = sanitize_blocks(chapter.get("blocks", []), evidence)
 
     def _get_chapter_swot_permission(self, chapter_id: str, context: Dict[str, Any]) -> bool:
         """

--- a/ReportEngine/prompts/prompts.py
+++ b/ReportEngine/prompts/prompts.py
@@ -351,7 +351,7 @@ SYSTEM_PROMPT_CHAPTER_JSON = f"""
 24. claim_type=inference 至少绑定2条不同证据；只有1条时必须标为 weak 并使用审慎措辞，没有证据时删除。claim_type=prediction/recommendation 必须标为 predicted，并单独放在预测/建议段落，不得与 fact/metric 混在同一block。
 25. citation_refs 是该block全部有效 claim 的 evidence_ids 去重并集。scope 尽量包含 subject、time_range、platform、condition；数据库证据还应保留 table、filters、time_window、sample_size、aggregation_method、row_ids。
 26. forumLogs 中的消息本身不是证据；只有其中显式 referenced_evidence_ids 指向 selectedEvidence 的条目才可帮助定位证据，仍须直接引用对应 evidence_id。旧纯文本论坛日志不得推断引用。
-27. selectedEvidence.evidence 为空时，不得生成具体事实、数字、比例、排名、涨跌或指标，只输出简短的“本章未检索到可追溯证据”。
+27. selectedEvidence.evidence 为空时，不得生成具体事实、数字、比例、排名、涨跌、指标或“未检索到证据”之类的占位文案，只保留章节 heading。
 
 <CHAPTER JSON SCHEMA>
 {CHAPTER_JSON_SCHEMA_TEXT}

--- a/ReportEngine/prompts/prompts.py
+++ b/ReportEngine/prompts/prompts.py
@@ -76,6 +76,15 @@ chapter_generation_input_schema = {
             "type": "array",
             "items": {"type": "object"}
         },
+        "selectedEvidence": {
+            "type": "object",
+            "properties": {
+                "sources": {"type": "array", "items": {"type": "object"}},
+                "evidence": {"type": "array", "items": {"type": "object"}},
+                "claims": {"type": "array", "items": {"type": "object"}}
+            }
+        },
+        "provenancePolicy": {"type": "object"},
         "constraints": {
             "type": "object",
             "properties": {
@@ -88,7 +97,7 @@ chapter_generation_input_schema = {
             }
         }
     },
-    "required": ["section", "globalContext", "reports"]
+    "required": ["section", "globalContext", "reports", "selectedEvidence", "provenancePolicy"]
 }
 
 # HTML报告生成输出Schema - 已简化，不再使用JSON格式
@@ -325,7 +334,7 @@ SYSTEM_PROMPT_CHAPTER_JSON = f"""
    - **特别注意：trend 字段只允许填写趋势评估（"正面利好"/"负面影响"/"中性"/"不确定"/"持续观察"）；任何关于趋势的文字叙述、详细说明、来源或扩展描述必须写入 detail 字段，禁止在 trend 字段中混入描述性文字。**
 8. 如需引用图表/交互组件，统一用widgetType表示（例如chart.js/line、chart.js/doughnut）。
 9. 鼓励结合outline中列出的子标题，生成多层heading与细粒度内容，同时可补充callout、blockquote等。
-10. engineQuote 仅用于呈现单Agent的原话：使用 block.type="engineQuote"，engine 取值 insight/media/query，title 必须固定为对应Agent名字（insight->Insight Agent，media->Media Agent，query->Query Agent，不可自定义），内部 blocks 只允许 paragraph，paragraph.inlines 的 marks 仅可使用 bold/italic（可留空），禁止在 engineQuote 中放表格/图表/引用/公式等；当 reports 或 forumLogs 中有明确的文字段落、结论、数字/时间等可直接引用时，优先分别从 Query/Media/Insight 三个 Agent 摘出关键原文或文字版数据放入 engineQuote，尽量覆盖三类 Agent 而非只用单一来源，严禁臆造内容或把表格/图表改写进 engineQuote。
+10. engineQuote 仅用于呈现能绑定 selectedEvidence.evidence 中 evidence_id 的 Agent 原话：使用 block.type="engineQuote"，engine 取值 insight/media/query，title 必须固定为对应Agent名字（insight->Insight Agent，media->Media Agent，query->Query Agent，不可自定义），内部 blocks 只允许 paragraph；reports 与 forumLogs 只能帮助理解讨论语境，绝不能单独作为证据。
 11. 如果chapterPlan中包含target/min/max或sections细分预算，请尽量贴合，必要时在notes允许的范围内突破，同时在结构上体现详略；
 12. 一级标题需使用中文数字（“一、二、三”），二级标题使用阿拉伯数字（“1.1、1.2”），heading.text中直接写好编号，与outline顺序对应；
 13. 严禁输出外部图片/AI生图链接，仅可使用Chart.js图表、表格、色块、callout等HTML原生组件；如需视觉辅助请改为文字描述或数据表；
@@ -337,6 +346,12 @@ SYSTEM_PROMPT_CHAPTER_JSON = f"""
 19. 所有widget块必须在顶层提供`data`或`dataRef`（可将props中的`data`上移），确保Chart.js能够直接渲染；缺失数据时宁可输出表格或段落，绝不留空。
 20. 任何block都必须声明合法`type`（heading/paragraph/list/...）；若需要普通文本请使用`paragraph`并给出`inlines`，禁止返回`type:null`或未知值。
 21. blockquote内容限制：blockquote块内部的blocks只允许包含paragraph类型的block，严禁在blockquote内嵌套表格（table）、列表（list）、图表（widget）、标题（heading）、代码块（code）、公式（math）、嵌套引用（blockquote）等任何非paragraph块；如果引用内容需要用表格/列表等复杂结构呈现，必须将其移到blockquote外部。
+22. 事实来源只能使用 selectedEvidence.evidence，本章不得引用完整 provenance 池，也不得编造 evidence_id。每个包含事实、数字、排名、涨跌、比例、时间或论据的block必须填写 claims、citation_refs、support_status。
+23. claims 中每项必须包含 claim_id、text、claim_type、text_span、evidence_ids、support_status、scope。claim_type=fact/metric 时至少绑定1个当前 selectedEvidence 中的 evidence_id；否则不要写入正文。
+24. claim_type=inference 至少绑定2条不同证据；只有1条时必须标为 weak 并使用审慎措辞，没有证据时删除。claim_type=prediction/recommendation 必须标为 predicted，并单独放在预测/建议段落，不得与 fact/metric 混在同一block。
+25. citation_refs 是该block全部有效 claim 的 evidence_ids 去重并集。scope 尽量包含 subject、time_range、platform、condition；数据库证据还应保留 table、filters、time_window、sample_size、aggregation_method、row_ids。
+26. forumLogs 中的消息本身不是证据；只有其中显式 referenced_evidence_ids 指向 selectedEvidence 的条目才可帮助定位证据，仍须直接引用对应 evidence_id。旧纯文本论坛日志不得推断引用。
+27. selectedEvidence.evidence 为空时，不得生成具体事实、数字、比例、排名、涨跌或指标，只输出简短的“本章未检索到可追溯证据”。
 
 <CHAPTER JSON SCHEMA>
 {CHAPTER_JSON_SCHEMA_TEXT}

--- a/ReportEngine/renderers/html_renderer.py
+++ b/ReportEngine/renderers/html_renderer.py
@@ -1204,6 +1204,15 @@ class HTMLRenderer:
     def _render_paragraph(self, block: Dict[str, Any]) -> str:
         """渲染段落，内部通过inline run保持混排样式"""
         inlines_data = block.get("inlines", [])
+
+        # 兼容已落盘的旧 IR：证据门禁淘汰全部主张后留下的占位段落
+        # 不应出现在用户看到的报告中。
+        if (
+            block.get("support_status") == "unsupported"
+            and not block.get("claims")
+            and not block.get("citation_refs")
+        ):
+            return ""
         
         # 检测并跳过包含文档元数据 JSON 的段落
         if self._is_metadata_paragraph(inlines_data):

--- a/ReportEngine/renderers/html_renderer.py
+++ b/ReportEngine/renderers/html_renderer.py
@@ -30,6 +30,7 @@ from ReportEngine.utils.chart_validator import (
 )
 from ReportEngine.utils.chart_repair_api import create_llm_repair_functions
 from ReportEngine.utils.chart_review_service import get_chart_review_service
+from common.provenance.citation_service import CitationService
 
 
 class HTMLRenderer:
@@ -110,6 +111,7 @@ class HTMLRenderer:
         self._current_chapter: Dict[str, Any] | None = None
         self._lib_cache: Dict[str, str] = {}
         self._pdf_font_base64: str | None = None
+        self.citation_service = CitationService()
 
         # 初始化图表验证和修复器
         self.chart_validator = create_chart_validator()
@@ -291,6 +293,7 @@ class HTMLRenderer:
             str: 可直接写入磁盘的完整HTML文档。
         """
         self.document = document_ir or {}
+        self.citation_service = CitationService(self.document.get("provenanceBundle"))
 
         # 使用统一的 ChartReviewService 进行图表审查与修复
         # 修复结果会直接回写到 document_ir，避免多次渲染重复修复
@@ -384,7 +387,7 @@ class HTMLRenderer:
         返回:
             str: head片段HTML。
         """
-        css = self._build_css(theme_tokens)
+        css = self._build_css(theme_tokens) + "\n" + self._citation_css()
 
         # 加载第三方库
         chartjs = self._load_lib("chart.js")
@@ -1213,7 +1216,75 @@ class HTMLRenderer:
                 return standalone
 
         inlines = "".join(self._render_inline(run) for run in inlines_data)
-        return f"<p>{inlines}</p>"
+        citations = self._render_citations(block)
+        support_status = str(block.get("support_status") or "")
+        classes = ["report-paragraph"]
+        if support_status in {"weak", "unsupported", "predicted"}:
+            classes.append(f"support-{support_status}")
+        label = self._render_claim_type_label(block)
+        class_attr = " ".join(classes)
+        return f'<p class="{class_attr}">{label}{inlines}{citations}</p>'
+
+    def _render_claim_type_label(self, block: Dict[str, Any]) -> str:
+        claim_types = {
+            str(item.get("claim_type") or "")
+            for item in block.get("claims", []) or []
+            if isinstance(item, dict)
+        }
+        if "prediction" in claim_types:
+            return '<span class="claim-kind-badge">预测</span>'
+        if "recommendation" in claim_types:
+            return '<span class="claim-kind-badge">建议</span>'
+        if block.get("support_status") == "weak":
+            return '<span class="claim-kind-badge weak">弱支持</span>'
+        return ""
+
+    def _render_citations(self, block: Dict[str, Any]) -> str:
+        evidence_ids = self.citation_service.evidence_ids_for_block(block)
+        fragments = []
+        for detail in self.citation_service.details_for_ids(evidence_ids):
+            evidence_id = self._escape_attr(detail["evidence_id"])
+            title = self._escape_html(detail.get("title") or "未命名来源")
+            platform = self._escape_html(detail.get("platform") or "未知平台")
+            publish_time = self._escape_html(detail.get("publish_time") or "时间未知")
+            snippet = self._escape_html(detail.get("snippet") or "无证据片段")
+            reason = self._escape_html(detail.get("selection_reason") or "与本段主张直接关联")
+            raw_url = str(detail.get("url") or "")
+            safe_url = raw_url if re.match(r"^https?://", raw_url, re.IGNORECASE) else f"#citation-{evidence_id}"
+            href = self._escape_attr(safe_url)
+            number = int(detail["number"])
+            fragments.append(
+                f'<sup class="citation-ref" id="citation-{evidence_id}" data-evidence-id="{evidence_id}">'
+                f'<a href="{href}" target="_blank" rel="noopener noreferrer" '
+                f'aria-label="查看来源 {number}">[{number}]</a>'
+                f'<span class="citation-tooltip" role="tooltip">'
+                f'<strong>{title}</strong><span>{platform} · {publish_time}</span>'
+                f'<span class="citation-snippet">{snippet}</span>'
+                f'<span class="citation-reason">引用理由：{reason}</span>'
+                f'</span></sup>'
+            )
+        return "".join(fragments)
+
+    @staticmethod
+    def _citation_css() -> str:
+        return """
+.report-paragraph { position: relative; }
+.citation-ref { position: relative; display: inline-block; margin-left: .18rem; font-size: .72em; line-height: 1; }
+.citation-ref > a { color: var(--primary, #0b6b57); font-weight: 700; text-decoration: none; }
+.citation-ref > a:hover, .citation-ref > a:focus { text-decoration: underline; }
+.citation-tooltip { position: absolute; z-index: 30; left: 50%; bottom: calc(100% + .55rem); width: min(22rem, 78vw); transform: translateX(-50%) translateY(.25rem); padding: .8rem .9rem; border: 1px solid rgba(20, 55, 48, .18); border-radius: .65rem; background: #fffdf7; color: #18352f; box-shadow: 0 12px 34px rgba(14, 42, 36, .18); font-size: .78rem; font-weight: 400; line-height: 1.45; opacity: 0; visibility: hidden; pointer-events: none; transition: opacity .16s ease, transform .16s ease; }
+.citation-tooltip > span { display: block; margin-top: .3rem; }
+.citation-tooltip .citation-snippet { max-height: 7.5rem; overflow: auto; }
+.citation-tooltip .citation-reason { color: #42675f; }
+.citation-ref:hover .citation-tooltip, .citation-ref:focus-within .citation-tooltip { opacity: 1; visibility: visible; transform: translateX(-50%) translateY(0); }
+.claim-kind-badge { display: inline-flex; margin-right: .45rem; padding: .12rem .42rem; border-radius: 999px; background: #fff0c2; color: #764d00; font-size: .72em; font-weight: 700; vertical-align: .1em; }
+.claim-kind-badge.weak { background: #f1ede3; color: #655d4e; }
+.support-predicted { border-left: 3px solid #d39a1e; padding-left: .75rem; }
+.support-weak { border-left: 3px solid #a99b7c; padding-left: .75rem; }
+.support-unsupported { color: #766f61; font-style: italic; }
+@media (max-width: 640px) { .citation-tooltip { left: auto; right: -1rem; transform: translateY(.25rem); } .citation-ref:hover .citation-tooltip, .citation-ref:focus-within .citation-tooltip { transform: translateY(0); } }
+@media print { .citation-tooltip { display: none; } .citation-ref > a { color: inherit; } }
+"""
 
     def _is_metadata_paragraph(self, inlines: List[Any]) -> bool:
         """

--- a/ReportEngine/renderers/markdown_renderer.py
+++ b/ReportEngine/renderers/markdown_renderer.py
@@ -148,6 +148,13 @@ class MarkdownRenderer:
 
     def _render_paragraph(self, block: Dict[str, Any]) -> str:
         inlines = block.get("inlines", [])
+        # 与 HTML/PDF 输出一致，隐藏旧 IR 中无主张、无引用的证据占位段落。
+        if (
+            block.get("support_status") == "unsupported"
+            and not block.get("claims")
+            and not block.get("citation_refs")
+        ):
+            return ""
         # 检测并跳过包含文档元数据 JSON 的段落
         if self._is_metadata_paragraph(inlines):
             return ""

--- a/ReportEngine/state/state.py
+++ b/ReportEngine/state/state.py
@@ -8,6 +8,8 @@ from typing import Dict, Any, Optional
 import json
 from datetime import datetime
 
+from common.provenance.models import ProvenanceBundle
+
 
 @dataclass
 class ReportMetadata:
@@ -44,6 +46,7 @@ class ReportState:
     media_engine_report: str = ""        # MediaEngine报告  
     insight_engine_report: str = ""      # InsightEngine报告
     forum_logs: str = ""                 # 论坛日志
+    provenance_bundle: ProvenanceBundle = field(default_factory=lambda: ProvenanceBundle(agent="report_engine"))
     
     # 处理结果
     selected_template: str = ""          # 选择的模板
@@ -100,6 +103,7 @@ class ReportState:
             "selected_template": self.selected_template,
             "has_html_content": bool(self.html_content),
             "html_content_length": len(self.html_content) if self.html_content else 0,
+            "provenance_bundle": self.provenance_bundle.to_dict(),
             "metadata": self.metadata.to_dict()
         }
     
@@ -129,6 +133,7 @@ class ReportState:
                 status=data.get("status", "pending"),
                 selected_template=data.get("selected_template", "")
             )
+            state.provenance_bundle = ProvenanceBundle.from_dict(data.get("provenance_bundle"))
             
             # 设置元数据
             metadata_data = data.get("metadata", {})

--- a/ReportEngine/utils/config.py
+++ b/ReportEngine/utils/config.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
     CHAPTER_JSON_MAX_ATTEMPTS: int = Field(
         2, description="章节JSON解析失败时的最大尝试次数"
     )
+    PROVENANCE_EVIDENCE_TOP_K: int = Field(
+        8, ge=1, le=50, description="每章注入的最大证据条数"
+    )
     TEMPLATE_DIR: str = Field("ReportEngine/report_template", description="多模板目录")
     API_TIMEOUT: float = Field(900.0, description="单API超时时间（秒）")
     MAX_RETRY_DELAY: float = Field(180.0, description="最大重试间隔（秒）")
@@ -92,6 +95,7 @@ def print_config(config: Settings):
     message += f"输出目录: {config.OUTPUT_DIR}\n"
     message += f"章节JSON目录: {config.CHAPTER_OUTPUT_DIR}\n"
     message += f"章节JSON最大尝试次数: {config.CHAPTER_JSON_MAX_ATTEMPTS}\n"
+    message += f"每章证据Top-K: {config.PROVENANCE_EVIDENCE_TOP_K}\n"
     message += f"整本IR目录: {config.DOCUMENT_IR_OUTPUT_DIR}\n"
     message += f"模板目录: {config.TEMPLATE_DIR}\n"
     message += f"API 超时时间: {config.API_TIMEOUT} 秒\n"

--- a/SingleEngineApp/insight_engine_streamlit_app.py
+++ b/SingleEngineApp/insight_engine_streamlit_app.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from InsightEngine import DeepSearchAgent, Settings
 from config import settings
+from common.provenance.runtime import publish_runtime_result
 from utils.github_issues import error_with_issue_link
 
 
@@ -82,8 +83,12 @@ def main():
     start_research = False
     query = auto_query
 
-    if auto_search and auto_query and 'auto_search_executed' not in st.session_state:
-        st.session_state.auto_search_executed = True
+    run_id = query_params.get('run_id', '')
+    if isinstance(run_id, list):
+        run_id = run_id[0] if run_id else ''
+    execution_key = run_id or auto_query
+    if auto_search and auto_query and st.session_state.get('auto_search_executed') != execution_key:
+        st.session_state.auto_search_executed = execution_key
         start_research = True
     elif auto_query and not auto_search:
         st.warning("等待搜索启动信号...")
@@ -127,10 +132,10 @@ def main():
         )
 
         # 执行研究
-        execute_research(query, config)
+        execute_research(query, config, run_id)
 
 
-def execute_research(query: str, config: Settings):
+def execute_research(query: str, config: Settings, run_id: str = ''):
     """执行研究"""
     try:
         # 创建进度条
@@ -169,6 +174,7 @@ def execute_research(query: str, config: Settings):
         # 生成最终报告
         status_text.text("正在生成最终报告...")
         final_report = agent._generate_final_report()
+        publish_runtime_result(run_id, 'insight', query, final_report, agent.state.provenance_bundle)
         progress_bar.progress(90)
 
         # 保存报告

--- a/SingleEngineApp/media_engine_streamlit_app.py
+++ b/SingleEngineApp/media_engine_streamlit_app.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from MediaEngine import DeepSearchAgent, AnspireSearchAgent, Settings
 from config import settings
+from common.provenance.runtime import publish_runtime_result
 from utils.github_issues import error_with_issue_link
 
 
@@ -83,8 +84,12 @@ def main():
     start_research = False
     query = auto_query
 
-    if auto_search and auto_query and 'auto_search_executed' not in st.session_state:
-        st.session_state.auto_search_executed = True
+    run_id = query_params.get('run_id', '')
+    if isinstance(run_id, list):
+        run_id = run_id[0] if run_id else ''
+    execution_key = run_id or auto_query
+    if auto_search and auto_query and st.session_state.get('auto_search_executed') != execution_key:
+        st.session_state.auto_search_executed = execution_key
         start_research = True
     elif auto_query and not auto_search:
         st.warning("等待搜索启动信号...")
@@ -146,10 +151,10 @@ def main():
             return
 
         # 执行研究
-        execute_research(query, config)
+        execute_research(query, config, run_id)
 
 
-def execute_research(query: str, config: Settings):
+def execute_research(query: str, config: Settings, run_id: str = ''):
     """执行研究"""
     try:
         # 创建进度条
@@ -194,6 +199,7 @@ def execute_research(query: str, config: Settings):
         status_text.text("正在生成最终报告...")
         logger.info("正在生成最终报告...")
         final_report = agent._generate_final_report()
+        publish_runtime_result(run_id, 'media', query, final_report, agent.state.provenance_bundle)
         progress_bar.progress(90)
 
         # 保存报告

--- a/SingleEngineApp/query_engine_streamlit_app.py
+++ b/SingleEngineApp/query_engine_streamlit_app.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from QueryEngine import DeepSearchAgent, Settings
 from config import settings
+from common.provenance.runtime import publish_runtime_result
 from utils.github_issues import error_with_issue_link
 
 
@@ -82,8 +83,12 @@ def main():
     start_research = False
     query = auto_query
 
-    if auto_search and auto_query and 'auto_search_executed' not in st.session_state:
-        st.session_state.auto_search_executed = True
+    run_id = query_params.get('run_id', '')
+    if isinstance(run_id, list):
+        run_id = run_id[0] if run_id else ''
+    execution_key = run_id or auto_query
+    if auto_search and auto_query and st.session_state.get('auto_search_executed') != execution_key:
+        st.session_state.auto_search_executed = execution_key
         start_research = True
     elif auto_query and not auto_search:
         st.warning("等待搜索启动信号...")
@@ -118,10 +123,10 @@ def main():
         )
 
         # 执行研究
-        execute_research(query, config)
+        execute_research(query, config, run_id)
 
 
-def execute_research(query: str, config: Settings):
+def execute_research(query: str, config: Settings, run_id: str = ''):
     """执行研究"""
     try:
         # 创建进度条
@@ -160,6 +165,7 @@ def execute_research(query: str, config: Settings):
         # 生成最终报告
         status_text.text("正在生成最终报告...")
         final_report = agent._generate_final_report()
+        publish_runtime_result(run_id, 'query', query, final_report, agent.state.provenance_bundle)
         progress_bar.progress(90)
 
         # 保存报告

--- a/app.py
+++ b/app.py
@@ -4,6 +4,10 @@ Flask主应用 - 统一管理三个Streamlit应用
 
 import os
 import sys
+import json
+import secrets
+import hmac
+from common.provenance.runtime import runtime_store
 
 # 【修复】尽早设置环境变量，确保所有模块都使用无缓冲模式
 os.environ['PYTHONIOENCODING'] = 'utf-8'
@@ -33,6 +37,7 @@ except ImportError as e:
     REPORT_ENGINE_AVAILABLE = False
 
 app = Flask(__name__)
+PROVENANCE_TOKEN = secrets.token_urlsafe(32)
 app.config['SECRET_KEY'] = 'Dedicated-to-creating-a-concise-and-versatile-public-opinion-analysis-platform'
 socketio = SocketIO(app, cors_allowed_origins="*")
 
@@ -397,6 +402,16 @@ def parse_forum_log_line(line):
 
     timestamp, raw_source, content = match.groups()
     source = raw_source.strip().upper()
+    referenced_evidence_ids = []
+    evidence_match = re.match(r'^\[EVIDENCE_IDS:(\[[^\]]*\])\]\s*(.*)$', content)
+    if evidence_match:
+        try:
+            referenced_evidence_ids = [
+                str(item) for item in json.loads(evidence_match.group(1)) if item
+            ]
+        except (TypeError, ValueError, json.JSONDecodeError):
+            referenced_evidence_ids = []
+        content = evidence_match.group(2)
 
     # 过滤掉系统消息和空内容
     if source == 'SYSTEM' or not content.strip():
@@ -422,7 +437,8 @@ def parse_forum_log_line(line):
         'sender': sender,
         'content': cleaned_content,
         'timestamp': timestamp,
-        'source': source
+        'source': source,
+        'referenced_evidence_ids': referenced_evidence_ids,
     }
 
 # Forum日志监听器
@@ -664,6 +680,8 @@ def start_streamlit_app(app_name, script_path, port):
         # 设置环境变量确保UTF-8编码和减少缓冲
         env = os.environ.copy()
         env.update({
+            'BETTAFISH_PROVENANCE_ENDPOINT': f"http://127.0.0.1:{_load_config_module().settings.PORT}/api/provenance/result",
+            'BETTAFISH_PROVENANCE_TOKEN': PROVENANCE_TOKEN,
             'PYTHONIOENCODING': 'utf-8',
             'PYTHONUTF8': '1',
             'LANG': 'en_US.UTF-8',
@@ -1148,6 +1166,29 @@ def get_forum_log_history():
         })
     except Exception as e:
         return jsonify({'success': False, 'message': f'读取forum历史失败: {str(e)}'})
+
+@app.route('/api/provenance/runs', methods=['POST'])
+def begin_provenance_run():
+    data = request.get_json(silent=True) or {}
+    try:
+        run_id = runtime_store.begin(str(data.get('query', '')), data.get('engines', []))
+        return jsonify({'success': True, 'run_id': run_id})
+    except (ValueError, TypeError, AttributeError) as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+
+
+@app.route('/api/provenance/result', methods=['POST'])
+def receive_provenance_result():
+    token = request.headers.get('X-Provenance-Token', '')
+    if request.remote_addr not in {'127.0.0.1', '::1'} or not hmac.compare_digest(token, PROVENANCE_TOKEN):
+        return jsonify({'success': False, 'error': 'unauthorized'}), 403
+    data = request.get_json(silent=True) or {}
+    try:
+        runtime_store.publish(data['run_id'], data['engine'], data['query'], data.get('report', ''), data.get('bundle'))
+        return jsonify({'success': True})
+    except (KeyError, ValueError, TypeError, AttributeError) as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+
 
 @app.route('/api/search', methods=['POST'])
 def search():

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared cross-engine utilities."""

--- a/common/provenance/__init__.py
+++ b/common/provenance/__init__.py
@@ -1,0 +1,40 @@
+"""Unified provenance contracts used by all BettaFish engines."""
+
+from .citation_service import CitationService
+from .models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord
+from .normalizer import (
+    add_search_results_to_bundle,
+    dedupe_bundle,
+    evidence_dedupe_key,
+    merge_bundles,
+    records_from_search_result,
+)
+from .selector import EvidenceSelector
+from .validators import (
+    ClaimGateResult,
+    filter_valid_evidence,
+    gate_claim,
+    gate_claims,
+    is_valid_evidence,
+    sanitize_claim_block,
+)
+
+__all__ = [
+    "CitationService",
+    "ClaimGateResult",
+    "ClaimRecord",
+    "EvidenceRecord",
+    "EvidenceSelector",
+    "ProvenanceBundle",
+    "SourceRecord",
+    "add_search_results_to_bundle",
+    "dedupe_bundle",
+    "evidence_dedupe_key",
+    "filter_valid_evidence",
+    "gate_claim",
+    "gate_claims",
+    "merge_bundles",
+    "is_valid_evidence",
+    "records_from_search_result",
+    "sanitize_claim_block",
+]

--- a/common/provenance/citation_service.py
+++ b/common/provenance/citation_service.py
@@ -1,0 +1,58 @@
+"""Resolve claim/evidence references into renderer-friendly citation details."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+from .models import EvidenceRecord, ProvenanceBundle, SourceRecord
+
+
+class CitationService:
+    def __init__(self, provenance: ProvenanceBundle | Mapping[str, Any] | None = None):
+        self.bundle = provenance if isinstance(provenance, ProvenanceBundle) else ProvenanceBundle.from_dict(provenance)
+        self.sources: Dict[str, SourceRecord] = {item.source_id: item for item in self.bundle.sources}
+        self.evidence: Dict[str, EvidenceRecord] = {item.evidence_id: item for item in self.bundle.evidence}
+        self._numbers: Dict[str, int] = {}
+
+    def evidence_ids_for_block(self, block: Mapping[str, Any]) -> List[str]:
+        ids: List[str] = []
+        ids.extend(str(item) for item in block.get("citation_refs", []) if item)
+        for claim in block.get("claims", []) or []:
+            if not isinstance(claim, Mapping):
+                continue
+            if claim.get("support_status") == "unsupported" or claim.get("status") == "unsupported":
+                continue
+            ids.extend(str(item) for item in claim.get("evidence_ids", []) if item)
+        return list(dict.fromkeys(item for item in ids if item in self.evidence))
+
+    def number_for(self, evidence_id: str) -> int:
+        if evidence_id not in self._numbers:
+            self._numbers[evidence_id] = len(self._numbers) + 1
+        return self._numbers[evidence_id]
+
+    def details_for_ids(self, evidence_ids: Iterable[str]) -> List[Dict[str, Any]]:
+        details = []
+        for evidence_id in evidence_ids:
+            evidence = self.evidence.get(str(evidence_id))
+            if evidence is None:
+                continue
+            source = self.sources.get(evidence.source_id, SourceRecord(source_id=evidence.source_id))
+            details.append(
+                {
+                    "number": self.number_for(evidence.evidence_id),
+                    "evidence_id": evidence.evidence_id,
+                    "source_id": evidence.source_id,
+                    "title": source.title or source.platform or evidence.evidence_id,
+                    "url": source.url,
+                    "platform": source.platform or source.meta.get("domain", ""),
+                    "author": source.author,
+                    "publish_time": source.publish_time,
+                    "retrieved_time": source.retrieved_time,
+                    "locator": source.locator,
+                    "evidence_type": evidence.evidence_type,
+                    "snippet": evidence.snippet,
+                    "scope": evidence.scope,
+                    "selection_reason": evidence.meta.get("selection_reason", ""),
+                }
+            )
+        return details

--- a/common/provenance/io.py
+++ b/common/provenance/io.py
@@ -1,0 +1,30 @@
+"""Audit/replay sidecar persistence; runtime code passes bundles directly."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Union
+
+from .models import ProvenanceBundle
+
+
+PathLike = Union[str, Path]
+
+
+def sidecar_path(report_path: PathLike) -> Path:
+    return Path(report_path).with_suffix(".provenance.json")
+
+
+def save_sidecar(bundle: ProvenanceBundle, report_path: PathLike) -> Path:
+    target = sidecar_path(report_path)
+    target.write_text(json.dumps(bundle.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    return target
+
+
+def load_sidecar(path_or_report: PathLike) -> ProvenanceBundle:
+    path = Path(path_or_report)
+    target = path if path.name.endswith(".provenance.json") else sidecar_path(path)
+    if not target.exists():
+        return ProvenanceBundle()
+    return ProvenanceBundle.from_dict(json.loads(target.read_text(encoding="utf-8")))

--- a/common/provenance/models.py
+++ b/common/provenance/models.py
@@ -1,0 +1,215 @@
+"""Stable, dependency-free provenance data contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, (tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _string(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+@dataclass
+class SourceRecord:
+    source_id: str = ""
+    agent: str = ""
+    source_type: str = "unknown"
+    title: str = ""
+    url: str = ""
+    platform: str = ""
+    author: str = ""
+    publish_time: str = ""
+    retrieved_time: str = field(default_factory=utc_now_iso)
+    locator: Dict[str, Any] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "agent": self.agent,
+            "source_type": self.source_type,
+            "title": self.title,
+            "url": self.url,
+            "platform": self.platform,
+            "author": self.author,
+            "publish_time": self.publish_time,
+            "retrieved_time": self.retrieved_time,
+            "locator": dict(self.locator),
+            "meta": dict(self.meta),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "SourceRecord":
+        data = data or {}
+        return cls(
+            source_id=_string(data.get("source_id") or data.get("id")),
+            agent=_string(data.get("agent")),
+            source_type=_string(data.get("source_type") or data.get("type") or "unknown"),
+            title=_string(data.get("title")),
+            url=_string(data.get("url")),
+            platform=_string(data.get("platform") or data.get("domain")),
+            author=_string(data.get("author")),
+            publish_time=_string(data.get("publish_time") or data.get("published_at")),
+            retrieved_time=_string(data.get("retrieved_time") or data.get("retrieved_at") or utc_now_iso()),
+            locator=_dict(data.get("locator")),
+            meta=_dict(data.get("meta")),
+        )
+
+
+@dataclass
+class EvidenceRecord:
+    evidence_id: str = ""
+    source_id: str = ""
+    agent: str = ""
+    evidence_type: str = "text"
+    snippet: str = ""
+    normalized_value: Any = None
+    scope: Dict[str, Any] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "evidence_id": self.evidence_id,
+            "source_id": self.source_id,
+            "agent": self.agent,
+            "evidence_type": self.evidence_type,
+            "snippet": self.snippet,
+            "normalized_value": self.normalized_value,
+            "scope": dict(self.scope),
+            "meta": dict(self.meta),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "EvidenceRecord":
+        data = data or {}
+        return cls(
+            evidence_id=_string(data.get("evidence_id") or data.get("id")),
+            source_id=_string(data.get("source_id")),
+            agent=_string(data.get("agent")),
+            evidence_type=_string(data.get("evidence_type") or data.get("type") or "text"),
+            snippet=_string(data.get("snippet") or data.get("content")),
+            normalized_value=data.get("normalized_value", data.get("value")),
+            scope=_dict(data.get("scope")),
+            meta=_dict(data.get("meta")),
+        )
+
+
+@dataclass
+class ClaimRecord:
+    claim_id: str = ""
+    text: str = ""
+    claim_type: str = "fact"
+    evidence_ids: List[str] = field(default_factory=list)
+    support_level: str = "unsupported"
+    status: str = "unsupported"
+    scope: Dict[str, Any] = field(default_factory=dict)
+    text_span: Dict[str, Any] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "text": self.text,
+            "claim_type": self.claim_type,
+            "evidence_ids": list(self.evidence_ids),
+            "support_level": self.support_level,
+            "status": self.status,
+            "support_status": self.status,
+            "scope": dict(self.scope),
+            "text_span": dict(self.text_span),
+            "meta": dict(self.meta),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "ClaimRecord":
+        data = data or {}
+        status = _string(data.get("status") or data.get("support_status") or "unsupported")
+        return cls(
+            claim_id=_string(data.get("claim_id") or data.get("id")),
+            text=_string(data.get("text")),
+            claim_type=_string(data.get("claim_type") or data.get("type") or "fact").lower(),
+            evidence_ids=[_string(item) for item in _list(data.get("evidence_ids") or data.get("citation_refs")) if _string(item)],
+            support_level=_string(data.get("support_level") or status),
+            status=status,
+            scope=_dict(data.get("scope")),
+            text_span=_dict(data.get("text_span")),
+            meta=_dict(data.get("meta")),
+        )
+
+
+@dataclass
+class ProvenanceBundle:
+    bundle_id: str = ""
+    agent: str = ""
+    sources: List[SourceRecord] = field(default_factory=list)
+    evidence: List[EvidenceRecord] = field(default_factory=list)
+    claims: List[ClaimRecord] = field(default_factory=list)
+    created_at: str = field(default_factory=utc_now_iso)
+    version: str = "1.0"
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def source_records(self) -> List[SourceRecord]:
+        return self.sources
+
+    @property
+    def evidence_records(self) -> List[EvidenceRecord]:
+        return self.evidence
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "bundle_id": self.bundle_id,
+            "agent": self.agent,
+            "sources": [item.to_dict() for item in self.sources],
+            "evidence": [item.to_dict() for item in self.evidence],
+            "claims": [item.to_dict() for item in self.claims],
+            "created_at": self.created_at,
+            "version": self.version,
+            "meta": dict(self.meta),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "ProvenanceBundle":
+        data = data or {}
+        sources = data.get("sources", data.get("source_records", []))
+        evidence = data.get("evidence", data.get("evidence_records", []))
+        return cls(
+            bundle_id=_string(data.get("bundle_id") or data.get("id")),
+            agent=_string(data.get("agent")),
+            sources=[SourceRecord.from_dict(item) for item in _list(sources) if isinstance(item, Mapping)],
+            evidence=[EvidenceRecord.from_dict(item) for item in _list(evidence) if isinstance(item, Mapping)],
+            claims=[ClaimRecord.from_dict(item) for item in _list(data.get("claims")) if isinstance(item, Mapping)],
+            created_at=_string(data.get("created_at") or utc_now_iso()),
+            version=_string(data.get("version") or "1.0"),
+            meta=_dict(data.get("meta")),
+        )
+
+    def add_records(
+        self,
+        sources: Iterable[SourceRecord] = (),
+        evidence: Iterable[EvidenceRecord] = (),
+        claims: Iterable[ClaimRecord] = (),
+    ) -> None:
+        self.sources.extend(sources)
+        self.evidence.extend(evidence)
+        self.claims.extend(claims)

--- a/common/provenance/normalizer.py
+++ b/common/provenance/normalizer.py
@@ -1,0 +1,261 @@
+"""Provenance normalization, stable identifiers, and typed deduplication."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import copy
+from dataclasses import replace
+from typing import Any, Dict, Iterable, Mapping, Tuple
+from urllib.parse import urlparse, urlunparse
+
+from .models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord, utc_now_iso
+
+
+def stable_id(prefix: str, *parts: Any) -> str:
+    payload = json.dumps(parts, ensure_ascii=False, sort_keys=True, default=str, separators=(",", ":"))
+    return f"{prefix}_{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:20]}"
+
+
+def content_hash(content: Any) -> str:
+    normalized = re.sub(r"\s+", " ", str(content or "")).strip()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def normalize_url(url: str) -> str:
+    value = str(url or "").strip()
+    if not value:
+        return ""
+    try:
+        parsed = urlparse(value)
+        return urlunparse((parsed.scheme.lower(), parsed.netloc.lower(), parsed.path.rstrip("/"), "", parsed.query, ""))
+    except ValueError:
+        return value
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str, separators=(",", ":"))
+
+
+def _lookup(record: EvidenceRecord, source: SourceRecord | None, key: str, default: Any = "") -> Any:
+    for mapping in (record.scope, record.meta, source.locator if source else {}, source.meta if source else {}):
+        if key in mapping and mapping[key] not in (None, "", [], {}):
+            return mapping[key]
+    return default
+
+
+def evidence_dedupe_key(record: EvidenceRecord, source: SourceRecord | None = None) -> Tuple[str, ...]:
+    """Return a source-type-specific identity key for one evidence record."""
+    evidence_type = (record.evidence_type or "").lower()
+    source_type = (source.source_type if source else "").lower()
+    kind = evidence_type or source_type
+
+    if kind == "db_row":
+        return (
+            "db_row",
+            str(_lookup(record, source, "table")),
+            _canonical(_lookup(record, source, "primary_key", _lookup(record, source, "record_id"))),
+        )
+    if kind == "db_agg":
+        return (
+            "db_agg",
+            str(_lookup(record, source, "table")),
+            str(_lookup(record, source, "metric")),
+            _canonical(_lookup(record, source, "filters", {})),
+            _canonical(_lookup(record, source, "time_window", {})),
+            str(_lookup(record, source, "aggregation_method")),
+        )
+    if kind in {"video", "comment"} or source_type in {"video", "comment"}:
+        post_id = _lookup(record, source, "post_id")
+        comment_id = _lookup(record, source, "comment_id")
+        timestamp = _lookup(record, source, "timestamp")
+        if not post_id and not comment_id:
+            return (kind, normalize_url(source.url if source else ""), str(timestamp), content_hash(record.snippet))
+        return (
+            "video_comment",
+            source.platform.lower() if source else "",
+            str(post_id), str(comment_id), str(timestamp),
+        )
+    if kind in {"web", "social", "text", "search_result", "ocr", "multimodal", "image_metadata"} or source_type in {"web", "social", "news"}:
+        url = normalize_url(source.url if source else str(record.meta.get("url", "")))
+        locator = source.locator if source else record.meta.get("locator", {})
+        digest = str(record.meta.get("content_hash") or content_hash(record.snippet))
+        return ("web_social", url, _canonical(locator), digest)
+
+    return ("generic", record.source_id, evidence_type, content_hash(record.snippet), _canonical(record.scope))
+
+
+def source_dedupe_key(source: SourceRecord) -> Tuple[str, ...]:
+    url = normalize_url(source.url)
+    if url:
+        return (source.source_type.lower(), url, _canonical(source.locator))
+    return (
+        source.source_type.lower(),
+        source.platform.lower(),
+        source.title.strip().lower(),
+        _canonical(source.locator),
+    )
+
+
+def dedupe_bundle(bundle: ProvenanceBundle) -> ProvenanceBundle:
+    bundle = copy.deepcopy(bundle)
+    source_by_key: Dict[Tuple[str, ...], SourceRecord] = {}
+    source_aliases: Dict[str, str] = {}
+    for source in bundle.sources:
+        key = source_dedupe_key(source)
+        kept = source_by_key.get(key)
+        if kept is None:
+            source_by_key[key] = source
+            source_aliases[source.source_id] = source.source_id
+        else:
+            source_aliases[source.source_id] = kept.source_id
+
+    sources = list(source_by_key.values())
+    source_index = {item.source_id: item for item in sources}
+    evidence_by_key: Dict[Tuple[str, ...], EvidenceRecord] = {}
+    evidence_aliases: Dict[str, str] = {}
+    for item in bundle.evidence:
+        canonical_source_id = source_aliases.get(item.source_id, item.source_id)
+        normalized = item if canonical_source_id == item.source_id else replace(item, source_id=canonical_source_id)
+        key = evidence_dedupe_key(normalized, source_index.get(canonical_source_id))
+        kept = evidence_by_key.get(key)
+        if kept is None:
+            evidence_by_key[key] = normalized
+            evidence_aliases[item.evidence_id] = normalized.evidence_id
+        else:
+            evidence_aliases[item.evidence_id] = kept.evidence_id
+
+    evidence = list(evidence_by_key.values())
+    claims = []
+    seen_claims = set()
+    for claim in bundle.claims:
+        claim.evidence_ids = list(dict.fromkeys(evidence_aliases.get(item, item) for item in claim.evidence_ids))
+        key = (claim.claim_type, claim.text.strip().lower(), tuple(claim.evidence_ids))
+        if key not in seen_claims:
+            claims.append(claim)
+            seen_claims.add(key)
+
+    aliases = dict(bundle.meta.get("evidence_aliases") or {})
+    aliases = {key: evidence_aliases.get(value, value) for key, value in aliases.items()}
+    aliases.update({key: value for key, value in evidence_aliases.items() if key != value})
+    return ProvenanceBundle(
+        bundle_id=bundle.bundle_id,
+        agent=bundle.agent,
+        sources=sources,
+        evidence=evidence,
+        claims=claims,
+        created_at=bundle.created_at,
+        version=bundle.version,
+        meta={**bundle.meta, "evidence_aliases": aliases},
+    )
+
+
+def merge_bundles(bundles: Iterable[ProvenanceBundle | Mapping[str, Any] | None]) -> ProvenanceBundle:
+    merged = ProvenanceBundle(agent="report_engine", bundle_id=stable_id("bundle", "report_engine", utc_now_iso()))
+    agents = []
+    for value in bundles:
+        if not value:
+            continue
+        bundle = value if isinstance(value, ProvenanceBundle) else ProvenanceBundle.from_dict(value)
+        if bundle.agent:
+            agents.append(bundle.agent)
+        merged.meta.setdefault("evidence_aliases", {}).update(bundle.meta.get("evidence_aliases") or {})
+        merged.add_records(bundle.sources, bundle.evidence, bundle.claims)
+    merged.meta["agents"] = list(dict.fromkeys(agents))
+    return dedupe_bundle(merged)
+
+
+def records_from_search_result(
+    agent: str,
+    result: Mapping[str, Any],
+    *,
+    query: str = "",
+    paragraph_title: str = "",
+    source_type: str = "web",
+    evidence_type: str = "web",
+    retrieved_time: str = "",
+) -> Tuple[SourceRecord, EvidenceRecord]:
+    """Normalize one existing engine result without changing its legacy output."""
+    snippet = str(result.get("raw_content") or result.get("content") or result.get("title_or_content") or "")
+    url = str(result.get("url") or "")
+    title = str(result.get("title") or result.get("title_or_content") or "")
+    platform = str(result.get("platform") or result.get("domain") or (urlparse(url).netloc if url else ""))
+    publish_time = result.get("publish_time") or result.get("published_date") or result.get("published_at") or ""
+    locator = dict(result.get("locator") or {})
+    for key in ("post_id", "comment_id", "timestamp", "table", "primary_key", "record_id"):
+        if result.get(key) not in (None, ""):
+            locator[key] = result[key]
+
+    source_id = stable_id("src", agent, source_type, normalize_url(url), locator, title)
+    source = SourceRecord(
+        source_id=source_id,
+        agent=agent,
+        source_type=source_type,
+        title=title,
+        url=url,
+        platform=platform,
+        author=str(result.get("author") or result.get("author_nickname") or ""),
+        publish_time=str(publish_time),
+        retrieved_time=retrieved_time or str(result.get("retrieved_time") or utc_now_iso()),
+        locator=locator,
+        meta={
+            "domain": str(result.get("domain") or (urlparse(url).netloc if url else "")),
+            "search_tool": str(result.get("search_tool") or ""),
+        },
+    )
+    scope = dict(result.get("scope") or {})
+    if query:
+        scope.setdefault("query", query)
+    if paragraph_title:
+        scope.setdefault("subject", paragraph_title)
+    evidence = EvidenceRecord(
+        evidence_id=stable_id("ev", source_id, evidence_type, locator, content_hash(snippet)),
+        source_id=source_id,
+        agent=agent,
+        evidence_type=evidence_type,
+        snippet=snippet,
+        normalized_value=result.get("normalized_value"),
+        scope=scope,
+        meta={"content_hash": content_hash(snippet)},
+    )
+    return source, evidence
+
+
+def add_search_results_to_bundle(
+    bundle: ProvenanceBundle,
+    *,
+    agent: str,
+    results: Iterable[Mapping[str, Any]],
+    query: str,
+    paragraph_title: str,
+    source_type: str = "web",
+    evidence_type: str = "web",
+) -> ProvenanceBundle:
+    """Add raw tool results and source-backed candidate claims to a bundle."""
+    for result in results:
+        item_source_type = str(result.get("source_type") or source_type)
+        item_evidence_type = str(result.get("evidence_type") or evidence_type)
+        source, evidence = records_from_search_result(
+            agent,
+            result,
+            query=query,
+            paragraph_title=paragraph_title,
+            source_type=item_source_type,
+            evidence_type=item_evidence_type,
+        )
+        if not evidence.snippet.strip():
+            continue
+        claim_text = str(result.get("claim_text") or evidence.snippet).strip()
+        claim = ClaimRecord(
+            claim_id=stable_id("claim", agent, claim_text, evidence.evidence_id),
+            text=claim_text,
+            claim_type=str(result.get("claim_type") or "fact"),
+            evidence_ids=[evidence.evidence_id],
+            support_level="supported",
+            status="supported",
+            scope=dict(evidence.scope),
+            meta={"candidate": True, "derived_from": "raw_tool_result"},
+        )
+        bundle.add_records([source], [evidence], [claim])
+    return dedupe_bundle(bundle)

--- a/common/provenance/runtime.py
+++ b/common/provenance/runtime.py
@@ -1,0 +1,90 @@
+"""Bounded, per-run in-memory transport between Streamlit workers and Flask."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import threading
+import uuid
+from collections import OrderedDict
+from urllib.request import Request, urlopen
+
+from .models import ProvenanceBundle
+from .normalizer import merge_bundles
+from .validators import filter_valid_evidence
+
+
+ENGINE_ORDER = ("query", "media", "insight")
+
+
+class RuntimeProvenanceStore:
+    def __init__(self, max_runs: int = 32):
+        self.max_runs = max_runs
+        self._runs = OrderedDict()
+        self._lock = threading.RLock()
+
+    def begin(self, query: str, engines=ENGINE_ORDER) -> str:
+        expected = [engine for engine in ENGINE_ORDER if engine in engines]
+        if not query.strip() or not expected:
+            raise ValueError("查询和参与引擎不能为空")
+        run_id = uuid.uuid4().hex
+        with self._lock:
+            self._runs[run_id] = {"query": query, "expected": expected, "engines": {}}
+            while len(self._runs) > self.max_runs:
+                self._runs.popitem(last=False)
+        return run_id
+
+    def publish(self, run_id: str, engine: str, query: str, report: str, bundle, complete: bool = True):
+        with self._lock:
+            run = self._runs.get(run_id)
+            if not run or query != run["query"] or engine not in run["expected"]:
+                raise ValueError("运行任务不存在，或查询/引擎不匹配")
+            provenance = ProvenanceBundle.from_dict(bundle.to_dict() if isinstance(bundle, ProvenanceBundle) else bundle)
+            if provenance.agent != f"{engine}_engine":
+                raise ValueError("bundle 与发布引擎不匹配")
+            provenance.meta.update({"run_id": run_id, "query": query})
+            # Empty evidence is an explicit result, never a request to reload old sidecars.
+            run["engines"][engine] = {
+                "report": str(report), "bundle": filter_valid_evidence(provenance), "complete": bool(complete),
+            }
+
+    def status(self, run_id: str) -> dict:
+        with self._lock:
+            run = self._runs.get(run_id)
+            if not run:
+                return {"ready": False, "missing_files": ["runtime task expired or unknown"], "latest_files": {}}
+            missing = [engine for engine in run["expected"] if not run["engines"].get(engine, {}).get("complete")]
+            return {"ready": not missing, "missing_files": missing, "latest_files": {}, "transport": "runtime"}
+
+    def inputs(self, run_id: str, query: str) -> dict:
+        with self._lock:
+            if not self.status(run_id)["ready"]:
+                raise ValueError("本轮 Agent 尚未全部提交运行态结果")
+            run = self._runs[run_id]
+            if query != run["query"]:
+                raise ValueError("报告查询与本轮任务不匹配")
+            entries = run["engines"]
+            return {
+                "reports": [entries.get(engine, {}).get("report", "") for engine in ENGINE_ORDER],
+                "provenance_bundle": merge_bundles([copy.deepcopy(item["bundle"]) for item in entries.values()]),
+                "forum_logs": "",
+            }
+
+
+runtime_store = RuntimeProvenanceStore()
+
+
+def publish_runtime_result(run_id: str, engine: str, query: str, report: str, bundle: ProvenanceBundle):
+    """Publish through the parent's loopback endpoint; standalone CLI has no endpoint."""
+    endpoint = os.environ.get("BETTAFISH_PROVENANCE_ENDPOINT", "")
+    if not run_id or not endpoint:
+        return
+    payload = json.dumps({"run_id": run_id, "engine": engine, "query": query, "report": report, "bundle": bundle.to_dict()}, ensure_ascii=False).encode("utf-8")
+    request = Request(endpoint, data=payload, headers={
+        "Content-Type": "application/json",
+        "X-Provenance-Token": os.environ.get("BETTAFISH_PROVENANCE_TOKEN", ""),
+    }, method="POST")
+    with urlopen(request, timeout=15) as response:
+        if response.status != 200:
+            raise RuntimeError("运行态证据提交失败")

--- a/common/provenance/selector.py
+++ b/common/provenance/selector.py
@@ -1,0 +1,117 @@
+"""Chapter-scoped evidence selection for bounded generation prompts."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Iterable, List, Mapping, Sequence, Tuple
+
+from .models import EvidenceRecord, ProvenanceBundle
+from .normalizer import dedupe_bundle, stable_id
+from .validators import gate_claims
+
+
+_WORD_RE = re.compile(r"[A-Za-z0-9_]{2,}|[\u4e00-\u9fff]")
+
+
+def _tokens(value: Any) -> set[str]:
+    text = str(value or "").lower()
+    tokens = set(_WORD_RE.findall(text))
+    for sequence in re.findall(r"[\u4e00-\u9fff]+", text):
+        tokens.update(sequence)
+        tokens.update(sequence[index:index + 2] for index in range(max(0, len(sequence) - 1)))
+    return {item for item in tokens if item}
+
+
+def _flatten(value: Any) -> str:
+    if isinstance(value, Mapping):
+        return " ".join(f"{key} {_flatten(item)}" for key, item in value.items())
+    if isinstance(value, (list, tuple, set)):
+        return " ".join(_flatten(item) for item in value)
+    return str(value or "")
+
+
+class EvidenceSelector:
+    def __init__(self, top_k: int = 8):
+        self.top_k = max(1, int(top_k))
+
+    def select(
+        self,
+        bundle: ProvenanceBundle | Mapping[str, Any] | None,
+        *,
+        chapter_topic: str,
+        chapter_draft: str = "",
+        claim_drafts: Sequence[str] | None = None,
+        top_k: int | None = None,
+    ) -> ProvenanceBundle:
+        source_bundle = bundle if isinstance(bundle, ProvenanceBundle) else ProvenanceBundle.from_dict(bundle)
+        # Selection ranks the candidate pool; strict source admission happens
+        # at the report boundary so chapter generation can still rank raw
+        # tool candidates that have not yet been enriched with a URL.
+        source_bundle = dedupe_bundle(source_bundle)
+        limit = max(1, int(top_k or self.top_k))
+        query_text = " ".join([chapter_topic or "", chapter_draft or "", " ".join(claim_drafts or [])]).strip()
+        query_tokens = _tokens(query_text)
+        source_index = {item.source_id: item for item in source_bundle.sources}
+
+        ranked: List[Tuple[float, int, EvidenceRecord, List[str]]] = []
+        for index, evidence in enumerate(source_bundle.evidence):
+            source = source_index.get(evidence.source_id)
+            candidate_text = " ".join(
+                [
+                    evidence.snippet,
+                    _flatten(evidence.scope),
+                    _flatten(evidence.normalized_value),
+                    source.title if source else "",
+                    source.platform if source else "",
+                ]
+            )
+            candidate_tokens = _tokens(candidate_text)
+            overlap = query_tokens & candidate_tokens
+            score = float(len(overlap))
+            reasons: List[str] = []
+            if overlap:
+                reasons.append("主题词匹配: " + "、".join(sorted(overlap)[:6]))
+            lowered_candidate = candidate_text.lower()
+            if chapter_topic and chapter_topic.lower() in lowered_candidate:
+                score += 4.0
+                reasons.append("直接匹配章节主题")
+            if evidence.scope.get("subject") and str(evidence.scope["subject"]).lower() in query_text.lower():
+                score += 2.0
+                reasons.append("证据范围与章节主题一致")
+            if not score:
+                continue
+            ranked.append((score, -index, evidence, reasons or ["作为当前章节的补充证据"] ))
+
+        ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        selected_evidence = []
+        selected_source_ids = set()
+        selected_ids = set()
+        for score, _, evidence, reasons in ranked[:limit]:
+            cloned = copy.deepcopy(evidence)
+            cloned.meta["selection_score"] = round(score, 4)
+            cloned.meta["selection_reason"] = "；".join(reasons)
+            selected_evidence.append(cloned)
+            selected_source_ids.add(cloned.source_id)
+            selected_ids.add(cloned.evidence_id)
+
+        selected_claims, _ = gate_claims(
+            [claim for claim in source_bundle.claims if set(claim.evidence_ids) & selected_ids],
+            selected_ids,
+        )
+        return ProvenanceBundle(
+            bundle_id=stable_id("bundle", source_bundle.bundle_id, chapter_topic, sorted(selected_ids)),
+            agent=source_bundle.agent,
+            sources=[copy.deepcopy(item) for item in source_bundle.sources if item.source_id in selected_source_ids],
+            evidence=selected_evidence,
+            claims=selected_claims,
+            version=source_bundle.version,
+            meta={
+                "selection": {
+                    "chapter_topic": chapter_topic,
+                    "top_k": limit,
+                    "pool_size": len(source_bundle.evidence),
+                    "selected_size": len(selected_evidence),
+                }
+            },
+        )

--- a/common/provenance/validators.py
+++ b/common/provenance/validators.py
@@ -1,0 +1,193 @@
+"""Evidence admission and claim-level gates. Never promote generated text to evidence."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Sequence, Tuple
+from urllib.parse import urlparse
+
+from .models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord
+from .normalizer import stable_id
+
+
+FACT_TYPES = {"fact", "metric"}
+FORECAST_TYPES = {"prediction", "recommendation"}
+VALID_STATUSES = {"supported", "weak", "unsupported", "predicted"}
+EMPTY_MESSAGE = "本段未检索到可追溯证据。"
+_RAW_TYPES = {"web", "social", "news", "text", "search_result", "ocr", "video", "comment", "multimodal", "db_row", "db_agg"}
+
+
+def is_valid_evidence(record: EvidenceRecord, source: SourceRecord | None = None) -> bool:
+    if not source or not record.evidence_id or not record.snippet.strip():
+        return False
+    if source.source_id != record.source_id:
+        return False
+    if "forum" in record.agent.lower() or "forum" in source.agent.lower():
+        return False
+    evidence_type = record.evidence_type.lower()
+    if evidence_type not in _RAW_TYPES or source.source_type.lower() not in _RAW_TYPES | {"database"}:
+        return False
+    if evidence_type in {"db_row", "db_agg"} or record.agent == "insight_engine":
+        if evidence_type not in {"db_row", "db_agg"}:
+            return False
+        scope = record.scope
+        required = {"query_time", "table", "filters", "time_window", "sample_size", "aggregation_method", "row_ids"}
+        if not required.issubset(scope):
+            return False
+        if not all(scope.get(key) for key in ("query_time", "table", "time_window", "aggregation_method", "row_ids")):
+            return False
+        if not isinstance(scope["filters"], Mapping) or not isinstance(scope["time_window"], Mapping):
+            return False
+        if not isinstance(scope["row_ids"], list) or any(item in (None, "") for item in scope["row_ids"]):
+            return False
+        try:
+            if int(scope["sample_size"]) <= 0:
+                return False
+        except (TypeError, ValueError, OverflowError):
+            return False
+        if evidence_type == "db_row" and scope.get("primary_key", scope.get("record_id")) in (None, ""):
+            return False
+        if evidence_type == "db_agg" and not scope.get("metric"):
+            return False
+        return True
+    try:
+        parsed = urlparse(source.url)
+        has_url = parsed.scheme.lower() in {"https", "http"} and bool(parsed.netloc)
+    except ValueError:
+        has_url = False
+    # A locator alone must identify a platform record, not an arbitrary label.
+    has_record = bool(source.platform and (source.locator.get("post_id") or source.locator.get("comment_id")))
+    return bool(has_url or has_record)
+
+
+def filter_valid_evidence(bundle: ProvenanceBundle) -> ProvenanceBundle:
+    result = copy.deepcopy(bundle)
+    source_index = {item.source_id: item for item in result.sources}
+    result.evidence = [item for item in result.evidence if is_valid_evidence(item, source_index.get(item.source_id))]
+    source_ids = {item.source_id for item in result.evidence}
+    result.sources = [item for item in result.sources if item.source_id in source_ids]
+    result.claims, _ = gate_claims(result.claims, result)
+    return result
+
+
+@dataclass
+class ClaimGateResult:
+    claim: ClaimRecord
+    allowed: bool
+    reason: str = ""
+
+
+def _numbers(text: str) -> set[str]:
+    return set(re.findall(r"(?<![A-Za-z])\d+(?:\.\d+)?", text.replace(",", "")))
+
+
+def gate_claim(claim: ClaimRecord | Mapping[str, Any], available_evidence_ids: Iterable[str] | ProvenanceBundle) -> ClaimGateResult:
+    record = copy.deepcopy(claim) if isinstance(claim, ClaimRecord) else ClaimRecord.from_dict(claim)
+    bundle = available_evidence_ids if isinstance(available_evidence_ids, ProvenanceBundle) else None
+    evidence_index = {item.evidence_id: item for item in bundle.evidence} if bundle else {}
+    available = set(evidence_index) if bundle else set(available_evidence_ids)
+    aliases = bundle.meta.get("evidence_aliases", {}) if bundle else {}
+    refs = [aliases.get(item, item) for item in record.evidence_ids]
+    record.evidence_ids = list(dict.fromkeys(item for item in refs if item in available))
+    record.claim_type = (record.claim_type or "fact").lower()
+    if not record.text.strip():
+        return ClaimGateResult(record, False, "claim 缺少正文")
+    if not record.claim_id:
+        record.claim_id = stable_id("claim", record.claim_type, record.text, record.evidence_ids)
+    if bundle and record.evidence_ids:
+        evidence = [evidence_index[item] for item in record.evidence_ids]
+        for key in ("subject", "time_range", "platform", "condition"):
+            values = [item.scope.get(key) for item in evidence if item.scope.get(key)]
+            if values and all(value == values[0] for value in values):
+                record.scope.setdefault(key, copy.deepcopy(values[0]))
+        if record.claim_type in FACT_TYPES:
+            # Retrieval dates and other metadata do not substantiate factual numbers.
+            support_text = " ".join(item.snippet + " " + json.dumps(item.normalized_value, ensure_ascii=False) for item in evidence)
+            if not _numbers(record.text).issubset(_numbers(support_text)):
+                record.evidence_ids = []
+
+    if record.claim_type in FACT_TYPES:
+        allowed = bool(record.evidence_ids)
+        record.status = record.support_level = "supported" if allowed else "unsupported"
+        return ClaimGateResult(record, allowed, "事实或指标必须绑定有效证据，数字必须出现在证据中")
+    if record.claim_type == "inference":
+        count = len(record.evidence_ids)
+        record.status = record.support_level = "supported" if count >= 2 else "weak" if count else "unsupported"
+        return ClaimGateResult(record, bool(count), "推断少于两条证据时降级为弱支持")
+    if record.claim_type in FORECAST_TYPES:
+        record.status = record.support_level = "predicted"
+        record.meta["display_label"] = "预测" if record.claim_type == "prediction" else "建议"
+        return ClaimGateResult(record, True, "预测或建议必须单独显示")
+    record.status = record.support_level = "unsupported"
+    return ClaimGateResult(record, False, "未知 claim 类型")
+
+
+def gate_claims(claims: Sequence[ClaimRecord | Mapping[str, Any]] | None, available_evidence_ids: Iterable[str] | ProvenanceBundle) -> Tuple[List[ClaimRecord], List[ClaimGateResult]]:
+    accepted, rejected = [], []
+    available = available_evidence_ids if isinstance(available_evidence_ids, ProvenanceBundle) else set(available_evidence_ids)
+    for claim in claims or []:
+        if not isinstance(claim, (ClaimRecord, Mapping)):
+            continue
+        result = gate_claim(claim, available)
+        (accepted if result.allowed else rejected).append(result.claim if result.allowed else result)
+    return accepted, rejected
+
+
+def _claim_paragraph(claims: List[ClaimRecord], empty_message: str = EMPTY_MESSAGE) -> dict:
+    cursor, parts = 0, []
+    for claim in claims:
+        if parts:
+            cursor += 1
+        claim.text_span = {"start": cursor, "end": cursor + len(claim.text)}
+        cursor += len(claim.text)
+        parts.append(claim.text)
+    statuses = {item.status for item in claims}
+    return {
+        "type": "paragraph",
+        "inlines": [{"text": " ".join(parts) if parts else empty_message}],
+        "claims": [item.to_dict() for item in claims],
+        "citation_refs": list(dict.fromkeys(ref for item in claims for ref in item.evidence_ids)),
+        "support_status": "predicted" if "predicted" in statuses else "weak" if "weak" in statuses else "supported" if claims else "unsupported",
+    }
+
+
+def sanitize_claim_block(block: Mapping[str, Any], available_evidence_ids: Iterable[str] | ProvenanceBundle, *, empty_message: str = EMPTY_MESSAGE) -> dict:
+    """Rebuild from allowed claims so unclaimed text cannot hitchhike on a citation."""
+    accepted, _ = gate_claims(block.get("claims"), available_evidence_ids)
+    return _claim_paragraph(accepted, empty_message)
+
+
+def sanitize_blocks(blocks: Any, evidence: Iterable[str] | ProvenanceBundle) -> list[dict]:
+    """Gate nested content and split forecasts from facts, preserving accepted claims."""
+    if not isinstance(blocks, list):
+        return []
+    result = []
+    for block in blocks:
+        if not isinstance(block, Mapping):
+            continue
+        kind = block.get("type")
+        if kind in {"heading", "hr", "pageBreak"} and not block.get("claims"):
+            result.append(copy.deepcopy(dict(block)))
+            continue
+        accepted, _ = gate_claims(block.get("claims"), evidence)
+        groups: dict[str, list[ClaimRecord]] = {}
+        for claim in accepted:
+            group = claim.claim_type if claim.claim_type in FORECAST_TYPES else claim.status
+            groups.setdefault(group, []).append(claim)
+        own = [_claim_paragraph(items) for items in groups.values()]
+        children = sanitize_blocks(block.get("blocks"), evidence)
+        for item in block.get("items", []) or []:
+            if isinstance(item, list):
+                children.extend(sanitize_blocks(item, evidence))
+        for row in block.get("rows", []) or []:
+            if not isinstance(row, Mapping):
+                continue
+            for cell in row.get("cells", []) or []:
+                if isinstance(cell, Mapping):
+                    children.extend(sanitize_blocks(cell.get("blocks"), evidence))
+        valid_children = [child for child in children if child.get("claims") or child.get("type") == "heading"]
+        result.extend(own + valid_children if own or valid_children else [_claim_paragraph([])])
+    return result

--- a/common/provenance/validators.py
+++ b/common/provenance/validators.py
@@ -189,5 +189,10 @@ def sanitize_blocks(blocks: Any, evidence: Iterable[str] | ProvenanceBundle) -> 
                 if isinstance(cell, Mapping):
                     children.extend(sanitize_blocks(cell.get("blocks"), evidence))
         valid_children = [child for child in children if child.get("claims") or child.get("type") == "heading"]
-        result.extend(own + valid_children if own or valid_children else [_claim_paragraph([])])
+        # Unsupported leaf blocks carry no user-visible information.  Dropping
+        # them here keeps the IR free of repeated "no evidence" placeholders;
+        # headings are preserved above so chapter structure and anchors remain
+        # stable even when a subsection has no admissible claims.
+        if own or valid_children:
+            result.extend(own + valid_children)
     return result

--- a/config.py
+++ b/config.py
@@ -102,6 +102,7 @@ class Settings(BaseSettings):
     MAX_PARAGRAPHS: int = Field(6, description="最大段落数")
     SEARCH_TIMEOUT: int = Field(240, description="单次搜索请求超时")
     MAX_CONTENT_LENGTH: int = Field(500000, description="搜索最大内容长度")
+    PROVENANCE_EVIDENCE_TOP_K: int = Field(8, ge=1, le=50, description="ReportEngine每章证据Top-K")
     
     model_config = ConfigDict(
         env_file=ENV_FILE,

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,0 +1,42 @@
+# 报告溯源与引用
+
+BettaFish 的报告溯源链分为 `SourceRecord`、`EvidenceRecord` 与
+`ClaimRecord` 三层，定义位于 `common/provenance/`：
+
+- `SourceRecord` 保存原始来源的标题、平台、作者、发布时间和 URL；
+- `EvidenceRecord` 保存从原始结果提取的可引用片段、来源 ID 和检索范围；
+- `ClaimRecord` 将报告中的事实、指标、推断、预测或建议绑定到证据 ID。
+
+这三层分别回答“来自哪里”“引用了哪段原始内容”和“报告中的哪项结论使用了它”。
+Query、Media 和 Insight 引擎会随各自结果保存 `.provenance.json` 审计文件。
+网页工作流还会为每次搜索创建独立的 `run_id`，子引擎经本机回调提交本轮结果，报告端只消费该轮的证据，避免使用旧搜索遗留的报告或侧车文件。
+
+## 报告行为
+
+章节生成前会按章节主题选择有限的相关证据，而不是把全文引擎报告当作证据输入。装订阶段会再次执行来源和主张门禁：
+
+- 事实和指标必须有有效证据 ID；结论中的数字还必须能在证据片段或标准化值中找到；
+- 推断只有一条证据时显示为“弱支持”，没有证据时不输出；
+- 预测和建议会与事实段落分开标记；
+- 论坛讨论文本只作为上下文，不能直接作为证据；
+- 未找到可追溯证据的内容会替换为明确的占位文本，而不会保留生成式结论。
+
+HTML 报告会在段落末尾显示引用上标。点击上标可打开原始 URL；悬浮详情包含来源标题、平台、发布时间、证据片段和“引用理由”。`Document IR` 还包含 `provenanceIndex` 和 `claimIndex`，便于审计、重渲染和程序化检查。
+
+Insight 的数据库证据保留表名、记录 ID、查询时间、筛选条件、时间窗口、样本量、聚合方法及行 ID 等血缘信息。若其来源没有公网 URL，页面仍显示这些可审计的内部来源信息，但不能跳转到外部网页。
+
+## 验证
+
+使用项目环境执行专项回归：
+
+```powershell
+conda run -n bettafish python -m pytest -q `
+  tests/test_provenance_models.py `
+  tests/test_provenance_dedupe.py `
+  tests/test_provenance_selector.py `
+  tests/test_provenance_claim_gate.py `
+  tests/test_provenance_runtime.py `
+  tests/test_html_citations.py
+```
+
+这组测试覆盖模型兼容、去重、章节选择、主张门禁、运行态隔离、无 URL 外部证据的拒绝，以及从装订后的 IR 到可点击 HTML 引用的完整路径。

--- a/report_engine_only.py
+++ b/report_engine_only.py
@@ -30,6 +30,10 @@ from typing import Dict, Any, Optional
 
 from loguru import logger
 
+from common.provenance.io import load_sidecar
+from common.provenance.models import ProvenanceBundle
+from common.provenance.normalizer import merge_bundles
+
 # 全局配置
 VERBOSE = False
 
@@ -183,7 +187,11 @@ def load_engine_reports(latest_files: Dict[str, str]) -> list[str]:
     """
     reports = []
 
-    for engine, file_path in latest_files.items():
+    for engine in ('query', 'media', 'insight'):
+        file_path = latest_files.get(engine)
+        if not file_path:
+            reports.append("")
+            continue
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 content = f.read()
@@ -193,6 +201,19 @@ def load_engine_reports(latest_files: Dict[str, str]) -> list[str]:
             logger.error(f"加载 {engine} 报告失败: {e}")
 
     return reports
+
+
+def load_provenance_bundle(latest_files: Dict[str, str]) -> ProvenanceBundle:
+    """Load audit sidecars only for CLI/replay compatibility."""
+    bundles = []
+    for engine in ('query', 'media', 'insight'):
+        file_path = latest_files.get(engine)
+        if not file_path:
+            continue
+        bundle = load_sidecar(file_path)
+        if bundle.evidence:
+            bundles.append(bundle)
+    return merge_bundles(bundles)
 
 
 def extract_query_from_reports(latest_files: Dict[str, str]) -> str:
@@ -221,7 +242,12 @@ def extract_query_from_reports(latest_files: Dict[str, str]) -> str:
     return "综合分析报告"
 
 
-def generate_report(reports: list[str], query: str, pdf_available: bool) -> Dict[str, Any]:
+def generate_report(
+    reports: list[str],
+    query: str,
+    pdf_available: bool,
+    provenance_bundle: Optional[ProvenanceBundle] = None,
+) -> Dict[str, Any]:
     """
     调用Report Engine生成报告
 
@@ -292,7 +318,8 @@ def generate_report(reports: list[str], query: str, pdf_available: bool) -> Dict
             forum_logs="",  # 不使用论坛日志
             custom_template="",  # 使用自动模板选择
             save_report=True,  # 自动保存报告
-            stream_handler=stream_handler
+            stream_handler=stream_handler,
+            provenance_bundle=provenance_bundle,
         )
 
         logger.success("✓ 报告生成成功！")
@@ -488,6 +515,7 @@ def main():
 
     # 加载报告内容
     reports = load_engine_reports(latest_files)
+    provenance_bundle = load_provenance_bundle(latest_files)
 
     if not reports:
         logger.error("❌ 未能加载任何报告内容")
@@ -498,7 +526,7 @@ def main():
     logger.info(f"使用报告主题: {query}")
 
     # 步骤 3: 生成报告
-    result = generate_report(reports, query, pdf_available)
+    result = generate_report(reports, query, pdf_available, provenance_bundle)
 
     # 步骤 4: 保存文件
     logger.info("\n" + "=" * 70)

--- a/templates/index.html
+++ b/templates/index.html
@@ -3012,7 +3012,7 @@
         }
 
         // 执行搜索
-        function performSearch() {
+        async function performSearch() {
             const query = document.getElementById('searchInput').value.trim();
             if (!query) {
                 showMessage('请输入搜索内容', 'error');
@@ -3022,6 +3022,21 @@
             const button = document.getElementById('searchButton');
             button.disabled = true;
             button.innerHTML = '<span class="loading"></span> 搜索中...';
+            try {
+                const engines = ['query', 'media', 'insight'].filter(name => appStatus[name] === 'running');
+                const response = await fetch('/api/provenance/runs', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ query, engines })
+                });
+                const result = await response.json();
+                if (!result.success) throw new Error(result.error || '无法创建分析任务');
+                provenanceRunId = result.run_id;
+            } catch (error) {
+                showMessage(error.message, 'error');
+                button.disabled = false;
+                button.textContent = '搜索';
+                return;
+            }
 
             // 清除现有报告，重置自动生成标志，为新搜索做准备
             const reportPreview = document.getElementById('reportPreview');
@@ -3058,7 +3073,7 @@
 
                     if (iframe) {
                         // 构建搜索URL
-                        const searchUrl = `http://${window.location.hostname}:${ports[app]}?query=${encodeURIComponent(query)}&auto_search=true`;
+                        const searchUrl = `http://${window.location.hostname}:${ports[app]}?query=${encodeURIComponent(query)}&auto_search=true&run_id=${encodeURIComponent(provenanceRunId)}`;
                         console.log(`向 ${app} 发送搜索请求: ${searchUrl}`);
 
                         // 检查iframe是否已经加载了相同的查询,避免不必要的重新加载
@@ -3074,7 +3089,7 @@
                             const newQuery = newUrl.searchParams.get('query');
 
                             // 如果query参数相同,不需要重新加载
-                            if (currentQuery === newQuery) {
+                            if (currentQuery === newQuery && currentUrl.searchParams.get('run_id') === provenanceRunId) {
                                 needsUpdate = false;
                                 console.log(`${app} iframe已有相同查询,跳过重新加载`);
                             }
@@ -3753,7 +3768,7 @@ function getConsoleContainer() {
         }
 
         function probeBackendConnection() {
-            fetch('/api/report/status?heartbeat=1', { cache: 'no-store' })
+            fetch(`/api/report/status?heartbeat=1&run_id=${encodeURIComponent(provenanceRunId)}`, { cache: 'no-store' })
             .then(response => {
                 if (!response.ok) throw new Error('heartbeat failed');
                 return response.json();
@@ -4446,7 +4461,7 @@ function getConsoleContainer() {
         let autoGenerateTriggered = false; // 防止重复触发
         
         function checkReportLockStatus() {
-            fetch('/api/report/status')
+            fetch(`/api/report/status?run_id=${encodeURIComponent(provenanceRunId)}`)
             .then(response => response.json())
             .then(data => {
                 const reportButton = document.querySelector('[data-app="report"]');
@@ -4675,6 +4690,7 @@ function getConsoleContainer() {
 
         // Report Engine 相关函数
         let reportTaskId = null;
+        let provenanceRunId = '';
         let reportPollingInterval = null;
         let reportEventSource = null;
         let reportLogRefreshInterval = null; // 日志刷新定时器
@@ -4691,7 +4707,7 @@ function getConsoleContainer() {
             const reportContent = document.getElementById('reportContent');
             
             // 检查ReportEngine状态
-            fetch('/api/report/status')
+            fetch(`/api/report/status?run_id=${encodeURIComponent(provenanceRunId)}`)
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
@@ -5177,7 +5193,7 @@ function getConsoleContainer() {
             addTaskProgressStatus('正在启动报告生成任务...', 'loading');
             
             // 构建请求数据，包含自定义模板（如果有的话）
-            const requestData = { query: query };
+            const requestData = { query: query, run_id: provenanceRunId };
             if (customTemplate && customTemplate.trim()) {
                 requestData.custom_template = customTemplate;
                 console.log('使用自定义模板生成报告');
@@ -5874,7 +5890,7 @@ function getConsoleContainer() {
         // 检查报告状态（不重新加载整个界面）
         function checkReportStatus() {
             // 只更新状态信息，不重新渲染整个界面
-            fetch('/api/report/status')
+            fetch(`/api/report/status?run_id=${encodeURIComponent(provenanceRunId)}`)
             .then(response => response.json())
             .then(data => {
                 if (data.success) {

--- a/tests/test_html_citations.py
+++ b/tests/test_html_citations.py
@@ -7,6 +7,20 @@ from ReportEngine.renderers.html_renderer import HTMLRenderer
 
 
 class HtmlCitationTests(unittest.TestCase):
+    def test_unsupported_placeholder_paragraph_is_not_rendered(self):
+        renderer = HTMLRenderer()
+        html = renderer._render_paragraph(
+            {
+                "type": "paragraph",
+                "inlines": [{"text": "本段未检索到可追溯证据。"}],
+                "claims": [],
+                "citation_refs": [],
+                "support_status": "unsupported",
+            }
+        )
+
+        self.assertEqual(html, "")
+
     def test_paragraph_renders_clickable_hover_citation(self):
         bundle = ProvenanceBundle(
             sources=[

--- a/tests/test_html_citations.py
+++ b/tests/test_html_citations.py
@@ -1,0 +1,111 @@
+import unittest
+
+from common.provenance.citation_service import CitationService
+from common.provenance.models import EvidenceRecord, ProvenanceBundle, SourceRecord
+from ReportEngine.core.stitcher import DocumentComposer
+from ReportEngine.renderers.html_renderer import HTMLRenderer
+
+
+class HtmlCitationTests(unittest.TestCase):
+    def test_paragraph_renders_clickable_hover_citation(self):
+        bundle = ProvenanceBundle(
+            sources=[
+                SourceRecord(
+                    source_id="s1",
+                    title="Official release",
+                    url="https://example.com/original",
+                    platform="example.com",
+                    publish_time="2026-09-01",
+                )
+            ],
+            evidence=[
+                EvidenceRecord(
+                    evidence_id="e1",
+                    source_id="s1",
+                    snippet="The reported value was 42.",
+                    meta={"selection_reason": "直接匹配章节主题"},
+                )
+            ],
+        )
+        renderer = HTMLRenderer()
+        renderer.citation_service = CitationService(bundle)
+        html = renderer._render_paragraph(
+            {
+                "type": "paragraph",
+                "inlines": [{"text": "The value was 42."}],
+                "claims": [
+                    {
+                        "claim_id": "c1",
+                        "text": "The value was 42.",
+                        "claim_type": "metric",
+                        "evidence_ids": ["e1"],
+                        "support_status": "supported",
+                    }
+                ],
+                "citation_refs": ["e1"],
+                "support_status": "supported",
+            }
+        )
+        self.assertIn('class="citation-ref"', html)
+        self.assertIn('href="https://example.com/original"', html)
+        self.assertIn("Official release", html)
+        self.assertIn("The reported value was 42.", html)
+        self.assertIn("直接匹配章节主题", html)
+
+    def test_composed_document_carries_a_claim_through_to_clickable_html(self):
+        bundle = ProvenanceBundle(
+            sources=[
+                SourceRecord(
+                    source_id="official-source",
+                    source_type="news",
+                    title="Official announcement",
+                    url="https://example.com/announcement",
+                    platform="example.com",
+                    publish_time="2026-09-01",
+                )
+            ],
+            evidence=[
+                EvidenceRecord(
+                    evidence_id="official-evidence",
+                    source_id="official-source",
+                    agent="query_engine",
+                    evidence_type="news",
+                    snippet="The official announcement reports 42 completed cases.",
+                    meta={"selection_reason": "官方公告直接给出该指标"},
+                )
+            ],
+        )
+        chapter = {
+            "chapterId": "S1",
+            "title": "Findings",
+            "order": 10,
+            "blocks": [
+                {"type": "heading", "level": 2, "text": "Findings", "anchor": "findings"},
+                {
+                    "type": "paragraph",
+                    "inlines": [{"text": "The official announcement reports 42 completed cases."}],
+                    "claims": [
+                        {
+                            "claim_id": "completed-cases",
+                            "text": "The official announcement reports 42 completed cases.",
+                            "claim_type": "metric",
+                            "evidence_ids": ["official-evidence"],
+                        }
+                    ],
+                },
+            ],
+        }
+
+        document = DocumentComposer().build_document("report-1", {}, [chapter], bundle)
+        html = HTMLRenderer().render(document)
+
+        self.assertIn("official-evidence", document["provenanceIndex"]["evidence"])
+        self.assertIn("completed-cases", document["claimIndex"])
+        self.assertTrue(document["provenanceEnforced"])
+        self.assertIn('href="https://example.com/announcement"', html)
+        self.assertIn('class="citation-ref"', html)
+        self.assertIn("引用理由：官方公告直接给出该指标", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_claim_gate.py
+++ b/tests/test_provenance_claim_gate.py
@@ -1,0 +1,72 @@
+import unittest
+
+from common.provenance.models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord
+from common.provenance.validators import filter_valid_evidence, gate_claim, sanitize_claim_block
+
+
+class ClaimGateTests(unittest.TestCase):
+    def test_fact_and_metric_require_evidence(self):
+        fact = gate_claim(ClaimRecord(claim_id="f", text="fact", claim_type="fact"), {"e1"})
+        metric = gate_claim(ClaimRecord(claim_id="m", text="42%", claim_type="metric"), {"e1"})
+        self.assertFalse(fact.allowed)
+        self.assertFalse(metric.allowed)
+
+    def test_inference_requires_two_and_prediction_is_marked(self):
+        weak = gate_claim(
+            ClaimRecord(claim_id="i", text="inference", claim_type="inference", evidence_ids=["e1"]),
+            {"e1", "e2"},
+        )
+        strong = gate_claim(
+            ClaimRecord(claim_id="i2", text="inference", claim_type="inference", evidence_ids=["e1", "e2"]),
+            {"e1", "e2"},
+        )
+        prediction = gate_claim(ClaimRecord(claim_id="p", text="future", claim_type="prediction"), set())
+        self.assertTrue(weak.allowed)
+        self.assertEqual(weak.claim.status, "weak")
+        self.assertEqual(strong.claim.status, "supported")
+        self.assertEqual(prediction.claim.status, "predicted")
+
+    def test_removes_only_unsupported_fact_from_mixed_block(self):
+        block = {
+            "type": "paragraph",
+            "inlines": [{"text": "Supported fact. Unsupported fact."}],
+            "claims": [
+                {"claim_id": "ok", "text": "Supported fact.", "claim_type": "fact", "evidence_ids": ["e1"]},
+                {"claim_id": "bad", "text": "Unsupported fact.", "claim_type": "fact", "evidence_ids": []},
+            ],
+        }
+        sanitized = sanitize_claim_block(block, {"e1"})
+        text = "".join(item["text"] for item in sanitized["inlines"])
+        self.assertIn("Supported fact.", text)
+        self.assertNotIn("Unsupported fact.", text)
+        self.assertEqual(sanitized["citation_refs"], ["e1"])
+
+    def test_empty_block_falls_back_only_after_all_claims_removed(self):
+        block = {
+            "type": "paragraph",
+            "inlines": [{"text": "Unsupported fact."}],
+            "claims": [{"claim_id": "bad", "text": "Unsupported fact.", "claim_type": "fact"}],
+        }
+        sanitized = sanitize_claim_block(block, set())
+        self.assertEqual(sanitized["inlines"][0]["text"], "本段未检索到可追溯证据。")
+
+    def test_insight_evidence_without_internal_lineage_is_filtered(self):
+        bundle = ProvenanceBundle(
+            agent="insight_engine",
+            sources=[SourceRecord(source_id="db", source_type="database", locator={"table": "posts"})],
+            evidence=[
+                EvidenceRecord(
+                    evidence_id="bad-db-row",
+                    source_id="db",
+                    agent="insight_engine",
+                    evidence_type="db_row",
+                    snippet="42 orders",
+                    scope={"table": "posts", "sample_size": 1},
+                )
+            ],
+        )
+        self.assertEqual(filter_valid_evidence(bundle).evidence, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_dedupe.py
+++ b/tests/test_provenance_dedupe.py
@@ -1,0 +1,45 @@
+import unittest
+
+from common.provenance.models import EvidenceRecord, ProvenanceBundle, SourceRecord
+from common.provenance.normalizer import dedupe_bundle
+
+
+class ProvenanceDedupeTests(unittest.TestCase):
+    def _deduped_count(self, evidence_type, locator=None, scope=None, snippet="same"):
+        locator = locator or {}
+        scope = scope or {}
+        bundle = ProvenanceBundle(
+            sources=[
+                SourceRecord(source_id="s1", source_type="web", url="https://example.com/item", locator=locator),
+                SourceRecord(source_id="s2", source_type="web", url="https://example.com/item/", locator=locator),
+            ],
+            evidence=[
+                EvidenceRecord(evidence_id="e1", source_id="s1", evidence_type=evidence_type, snippet=snippet, scope=scope),
+                EvidenceRecord(evidence_id="e2", source_id="s2", evidence_type=evidence_type, snippet=snippet, scope=scope),
+            ],
+        )
+        return len(dedupe_bundle(bundle).evidence)
+
+    def test_web_uses_url_locator_and_content_hash(self):
+        self.assertEqual(self._deduped_count("web", locator={"page": 2}), 1)
+
+    def test_video_comment_uses_post_comment_timestamp(self):
+        scope = {"post_id": "p1", "comment_id": "c1", "timestamp": "00:42"}
+        self.assertEqual(self._deduped_count("comment", scope=scope), 1)
+
+    def test_db_row_uses_table_and_primary_key(self):
+        self.assertEqual(self._deduped_count("db_row", scope={"table": "posts", "primary_key": 7}), 1)
+
+    def test_db_agg_uses_full_query_signature(self):
+        scope = {
+            "table": "posts",
+            "metric": "count",
+            "filters": {"platform": "weibo"},
+            "time_window": {"start": "2026-01-01", "end": "2026-01-31"},
+            "aggregation_method": "count",
+        }
+        self.assertEqual(self._deduped_count("db_agg", scope=scope), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_models.py
+++ b/tests/test_provenance_models.py
@@ -1,0 +1,41 @@
+import unittest
+
+from common.provenance.models import ClaimRecord, EvidenceRecord, ProvenanceBundle, SourceRecord
+
+
+class ProvenanceModelTests(unittest.TestCase):
+    def test_bundle_roundtrip_preserves_records(self):
+        bundle = ProvenanceBundle(
+            bundle_id="bundle-1",
+            agent="query_engine",
+            sources=[SourceRecord(source_id="src-1", title="Source", url="https://example.com/a")],
+            evidence=[EvidenceRecord(evidence_id="ev-1", source_id="src-1", snippet="Evidence")],
+            claims=[ClaimRecord(claim_id="cl-1", text="Claim", evidence_ids=["ev-1"], status="supported")],
+        )
+
+        restored = ProvenanceBundle.from_dict(bundle.to_dict())
+
+        self.assertEqual(restored.bundle_id, "bundle-1")
+        self.assertEqual(restored.sources[0].url, "https://example.com/a")
+        self.assertEqual(restored.evidence[0].snippet, "Evidence")
+        self.assertEqual(restored.claims[0].evidence_ids, ["ev-1"])
+
+    def test_legacy_and_missing_fields_get_stable_defaults(self):
+        bundle = ProvenanceBundle.from_dict(
+            {
+                "agent": "legacy",
+                "source_records": [{"id": "src-old", "published_at": "2026-01-01"}],
+                "evidence_records": [{"id": "ev-old", "content": "legacy evidence"}],
+                "claims": [{"id": "cl-old", "citation_refs": "ev-old"}],
+            }
+        )
+
+        self.assertEqual(bundle.sources[0].source_id, "src-old")
+        self.assertEqual(bundle.sources[0].publish_time, "2026-01-01")
+        self.assertEqual(bundle.evidence[0].snippet, "legacy evidence")
+        self.assertEqual(bundle.claims[0].evidence_ids, ["ev-old"])
+        self.assertIsInstance(bundle.meta, dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_runtime.py
+++ b/tests/test_provenance_runtime.py
@@ -65,10 +65,11 @@ class RuntimeProvenanceTests(unittest.TestCase):
 
         document = DocumentComposer().build_document("report-1", {}, [chapter], bundle)
 
-        paragraph = document["chapters"][0]["blocks"][0]
         self.assertEqual(document["provenanceIndex"]["evidence"], {})
-        self.assertEqual(paragraph["support_status"], "unsupported")
-        self.assertEqual(paragraph["inlines"][0]["text"], "本段未检索到可追溯证据。")
+        blocks = document["chapters"][0]["blocks"]
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["type"], "heading")
+        self.assertNotIn("本段未检索到可追溯证据", str(blocks))
 
 
 if __name__ == "__main__":

--- a/tests/test_provenance_runtime.py
+++ b/tests/test_provenance_runtime.py
@@ -1,0 +1,75 @@
+import unittest
+
+from common.provenance.models import EvidenceRecord, ProvenanceBundle, SourceRecord
+from common.provenance.runtime import RuntimeProvenanceStore
+from ReportEngine.core.stitcher import DocumentComposer
+
+
+class RuntimeProvenanceTests(unittest.TestCase):
+    def test_empty_engine_result_is_retained_for_the_current_run(self):
+        store = RuntimeProvenanceStore()
+        run_id = store.begin("test topic", ["query", "insight"])
+        store.publish(
+            run_id,
+            "query",
+            "test topic",
+            "query report",
+            ProvenanceBundle(agent="query_engine"),
+        )
+        store.publish(
+            run_id,
+            "insight",
+            "test topic",
+            "no internal evidence",
+            ProvenanceBundle(agent="insight_engine"),
+        )
+
+        inputs = store.inputs(run_id, "test topic")
+
+        self.assertEqual(inputs["reports"], ["query report", "", "no internal evidence"])
+        self.assertEqual(inputs["provenance_bundle"].evidence, [])
+
+    def test_document_composer_rejects_external_evidence_without_a_source_url(self):
+        bundle = ProvenanceBundle(
+            agent="query_engine",
+            sources=[SourceRecord(source_id="source-1", source_type="web", title="missing link")],
+            evidence=[
+                EvidenceRecord(
+                    evidence_id="evidence-1",
+                    source_id="source-1",
+                    agent="query_engine",
+                    evidence_type="web",
+                    snippet="A claimed fact.",
+                )
+            ],
+        )
+        chapter = {
+            "chapterId": "S1",
+            "title": "Evidence",
+            "order": 10,
+            "blocks": [
+                {
+                    "type": "paragraph",
+                    "inlines": [{"text": "A claimed fact."}],
+                    "claims": [
+                        {
+                            "claim_id": "claim-1",
+                            "text": "A claimed fact.",
+                            "claim_type": "fact",
+                            "evidence_ids": ["evidence-1"],
+                        }
+                    ],
+                }
+            ],
+        }
+
+        document = DocumentComposer().build_document("report-1", {}, [chapter], bundle)
+
+        paragraph = document["chapters"][0]["blocks"][0]
+        self.assertEqual(document["provenanceIndex"]["evidence"], {})
+        self.assertEqual(paragraph["support_status"], "unsupported")
+        self.assertEqual(paragraph["inlines"][0]["text"], "本段未检索到可追溯证据。")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_selector.py
+++ b/tests/test_provenance_selector.py
@@ -1,0 +1,28 @@
+import unittest
+
+from common.provenance.models import EvidenceRecord, ProvenanceBundle, SourceRecord
+from common.provenance.selector import EvidenceSelector
+
+
+class EvidenceSelectorTests(unittest.TestCase):
+    def test_selects_only_top_k_relevant_evidence(self):
+        bundle = ProvenanceBundle(
+            sources=[SourceRecord(source_id=f"s{i}", title=f"source {i}") for i in range(4)],
+            evidence=[
+                EvidenceRecord(evidence_id="climate-1", source_id="s0", snippet="climate policy and carbon market"),
+                EvidenceRecord(evidence_id="sports-1", source_id="s1", snippet="football league score"),
+                EvidenceRecord(evidence_id="climate-2", source_id="s2", snippet="carbon emissions policy update"),
+                EvidenceRecord(evidence_id="music-1", source_id="s3", snippet="concert ticket sales"),
+            ],
+        )
+
+        selected = EvidenceSelector(top_k=2).select(bundle, chapter_topic="climate carbon policy")
+
+        self.assertEqual(len(selected.evidence), 2)
+        self.assertEqual({item.evidence_id for item in selected.evidence}, {"climate-1", "climate-2"})
+        self.assertLess(len(selected.evidence), len(bundle.evidence))
+        self.assertTrue(all(item.meta.get("selection_reason") for item in selected.evidence))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

当前研究报告虽然会汇总搜索结果，但消息、报告主张与原始检索来源之间缺少稳定的结构化关联，读者难以判断每条结论来自哪里，也难以回溯原始证据。

## 主要改动

- 新增统一的 `common/provenance` 来源溯源模块，负责来源标准化、去重、持久化、证据选择与引用校验。
- 为 QueryEngine、InsightEngine、MediaEngine 和 ForumEngine 补充结构化来源与证据传递。
- 扩展 ReportEngine IR、章节生成、报告拼接及 HTML/Markdown 渲染，支持主张级引用和来源列表。
- 前端与 SingleEngineApp 展示消息来源及证据数量，保留可点击的原始链接。
- 没有可追溯证据时不再显示占位提示。
- 新增来源溯源说明文档和专项回归测试。

## 兼容性

- 原有字符串搜索结果仍可通过标准化层兼容处理。
- 缺少来源不会阻断原有研究流程。
- 新增 `PROVENANCE_EVIDENCE_TOP_K` 配置，默认每章最多注入 8 条证据。

## 验证

来源溯源专项测试结果：

`17 passed, 15 warnings in 11.54s`

现有警告来自 Pydantic 2 和 Matplotlib/Pyparsing 的弃用提示，与本次改动无关。

## 安全检查

提交差异中未包含 API Key、Bearer Token、私钥或 `.env` 文件。